### PR TITLE
Get the build number from git tag not hard coded in build.gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,11 @@ plugins {
     id 'maven'
 }
 
+def buildNumber = System.getenv("TRAVIS_BRANCH") ?: "DEV-SNAPSHOT"
+
 group 'uk.gov.hmcts.reform'
-version '0.0.124'
+// Do not change this version number
+version buildNumber
 
 sourceCompatibility = 1.8
 


### PR DESCRIPTION
 This will stop us having to update the build.gradle file every time we want
to release a new version.