### PR TITLE
SSCS-4658: Check for mobile number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ dependencies {
     compile group: 'com.github.sps.junidecode', name: 'junidecode', version: '0.3'
     compile group: 'org.apache.poi', name: 'poi-ooxml', version: '3.17'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.3'
+    compile group: 'com.googlecode.libphonenumber', name: 'libphonenumber', version: '8.10.3'
 
     compileOnly 'org.projectlombok:lombok:1.16.20'
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/utility/PhoneNumbersUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/utility/PhoneNumbersUtil.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.reform.sscs.utility;
+
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.Phonenumber;
+import java.util.Locale;
+import java.util.Optional;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+public final class PhoneNumbersUtil {
+
+    private static final String DEFAULT_REGION = Locale.UK.getCountry();
+
+    private PhoneNumbersUtil() {
+        // Void
+    }
+
+    public static String cleanPhoneNumber(final String phone) {
+        final PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
+        final Optional<Phonenumber.PhoneNumber> phoneNumberOpt = parsePhoneNumber(phone, phoneNumberUtil);
+        return phoneNumberOpt.map(phoneNumber -> String.format("+%d%d", phoneNumber.getCountryCode(), phoneNumber.getNationalNumber())).orElse("");
+    }
+
+    public static boolean isValidUkMobileNumber(final String phone) {
+        final PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
+        final Optional<Phonenumber.PhoneNumber> phoneNumberOpt = parsePhoneNumber(phone, phoneNumberUtil);
+        return containsPhoneNumberType(phoneNumberUtil, phoneNumberOpt,
+                PhoneNumberUtil.PhoneNumberType.MOBILE, PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE) &&
+                phoneNumberOpt.map(phoneNumber -> 44 == phoneNumber.getCountryCode()).orElse(false);
+    }
+
+    public static boolean isValidMobileNumber(final String phone) {
+        return isValidNumber(phone, PhoneNumberUtil.PhoneNumberType.MOBILE, PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE);
+    }
+
+    public static boolean isValidLandLineNumber(final String phone) {
+        return isValidNumber(phone, PhoneNumberUtil.PhoneNumberType.FIXED_LINE, PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE);
+    }
+
+    private static boolean isValidNumber(final String phone, final PhoneNumberUtil.PhoneNumberType... phoneNumberTypes) {
+        final PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
+        final Optional<Phonenumber.PhoneNumber> phoneNumberOpt = parsePhoneNumber(phone, phoneNumberUtil);
+        return containsPhoneNumberType(phoneNumberUtil, phoneNumberOpt, phoneNumberTypes);
+    }
+
+    private static boolean containsPhoneNumberType(final PhoneNumberUtil phoneNumberUtil,
+                                                   final Optional<Phonenumber.PhoneNumber> phoneNumberOpt,
+                                                   final PhoneNumberUtil.PhoneNumberType... phoneNumberTypes) {
+        return phoneNumberOpt.map(phoneNumber ->
+                ArrayUtils.contains(phoneNumberTypes, phoneNumberUtil.getNumberType(phoneNumber))).orElse(false);
+    }
+
+    private static Optional<Phonenumber.PhoneNumber> parsePhoneNumber(final String phone,
+                                                                      final PhoneNumberUtil phoneNumberUtil) {
+        Optional<Phonenumber.PhoneNumber> phoneNumberOpt = Optional.empty();
+        try {
+            phoneNumberOpt = Optional.of(phoneNumberUtil.parse(phone, DEFAULT_REGION));
+        } catch (final Exception ignored) {
+            // ignored
+        }
+        return phoneNumberOpt;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/utility/PhoneNumbersUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/utility/PhoneNumbersUtil.java
@@ -15,10 +15,10 @@ public final class PhoneNumbersUtil {
         // Void
     }
 
-    public static String cleanPhoneNumber(final String phone) {
+    public static Optional<String> cleanPhoneNumber(final String phone) {
         final PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
         final Optional<Phonenumber.PhoneNumber> phoneNumberOpt = parsePhoneNumber(phone, phoneNumberUtil);
-        return phoneNumberOpt.map(phoneNumber -> String.format("+%d%d", phoneNumber.getCountryCode(), phoneNumber.getNationalNumber())).orElse("");
+        return phoneNumberOpt.map(phoneNumber -> String.format("+%d%d", phoneNumber.getCountryCode(), phoneNumber.getNationalNumber()));
     }
 
     public static boolean isValidUkMobileNumber(final String phone) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/utility/PhoneNumbersUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/utility/PhoneNumbersUtilTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Optional;
 import org.junit.Test;
 
 @SuppressWarnings({"PMD.JUnitTestContainsTooManyAsserts", "PMD.LongVariable"})
@@ -65,22 +66,27 @@ public class PhoneNumbersUtilTest {
     }
 
     @Test
-    public void cleanNumberTestForUkMobile() {
-        assertEquals(ASSERTION_EQUALS_MESSAGE, "+447861675377", PhoneNumbersUtil.cleanPhoneNumber(UK_MOBILE_NUMBER));
+    public void cleanNumberForUkMobile() {
+        assertEquals(ASSERTION_EQUALS_MESSAGE, Optional.of("+447861675377"), PhoneNumbersUtil.cleanPhoneNumber(UK_MOBILE_NUMBER));
     }
 
     @Test
-    public void cleanNumberTestForUkLandLine() {
-        assertEquals(ASSERTION_EQUALS_MESSAGE, "+442037374299", PhoneNumbersUtil.cleanPhoneNumber(UK_LAND_LINE));
+    public void cleanNumberForUkLandLine() {
+        assertEquals(ASSERTION_EQUALS_MESSAGE, Optional.of("+442037374299"), PhoneNumbersUtil.cleanPhoneNumber(UK_LAND_LINE));
     }
 
     @Test
-    public void cleanNumberTestForUkLandLineWithCountryCode() {
-        assertEquals(ASSERTION_EQUALS_MESSAGE, "+442037374299", PhoneNumbersUtil.cleanPhoneNumber(UK_LAND_LINE_WITH_COUNTRY_CODE));
+    public void cleanNumberForUkLandLineWithCountryCode() {
+        assertEquals(ASSERTION_EQUALS_MESSAGE, Optional.of("+442037374299"), PhoneNumbersUtil.cleanPhoneNumber(UK_LAND_LINE_WITH_COUNTRY_CODE));
     }
 
     @Test
-    public void cleanNumberTestForAnAmericanLandLine() {
-        assertEquals(ASSERTION_EQUALS_MESSAGE, "+15417543010", PhoneNumbersUtil.cleanPhoneNumber(US_LAND_LINE_WITH_COUNTRY_CODE));
+    public void cleanNumberForAnAmericanLandLine() {
+        assertEquals(ASSERTION_EQUALS_MESSAGE, Optional.of("+15417543010"), PhoneNumbersUtil.cleanPhoneNumber(US_LAND_LINE_WITH_COUNTRY_CODE));
+    }
+
+    @Test
+    public void cleanNumberForAnInvalidNumberReturnsEmptyOption() {
+        assertEquals(ASSERTION_EQUALS_MESSAGE, Optional.empty(), PhoneNumbersUtil.cleanPhoneNumber("99a"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/utility/PhoneNumbersUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/utility/PhoneNumbersUtilTest.java
@@ -1,0 +1,86 @@
+package uk.gov.hmcts.reform.sscs.utility;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+@SuppressWarnings({"PMD.JUnitTestContainsTooManyAsserts", "PMD.LongVariable"})
+public class PhoneNumbersUtilTest {
+
+    private static final String UK_MOBILE_NUMBER = "07861675377";
+    private static final String UK_MOBILE_NUMBER_WITH_COUNTRY_CODE = "(+44) 7861675377";
+    private static final String UK_LAND_LINE = "0203 737 4299";
+    private static final String UK_LAND_LINE_WITH_COUNTRY_CODE = "+44 203 737 4299";
+    private static final String US_LAND_LINE_WITH_COUNTRY_CODE = "+1-541-754-3010";
+    private static final String ASSERTION_FALSE_MESSAGE = "Does not equal false";
+    private static final String ASSERTION_TRUE_MESSAGE = "Does not equal true";
+    private static final String ASSERTION_EQUALS_MESSAGE = "Is not equal";
+
+    @Test
+    public void isValidMobileNumberWillReturnTrueForAUkMobileNumber() {
+        assertTrue(ASSERTION_TRUE_MESSAGE, PhoneNumbersUtil.isValidMobileNumber(UK_MOBILE_NUMBER));
+        assertTrue(ASSERTION_TRUE_MESSAGE, PhoneNumbersUtil.isValidMobileNumber(UK_MOBILE_NUMBER_WITH_COUNTRY_CODE));
+    }
+
+    @Test
+    public void isValidMobileNumberWillReturnFalseForLandLineOrInvalidValues() {
+        assertFalse(ASSERTION_FALSE_MESSAGE, PhoneNumbersUtil.isValidMobileNumber(""));
+        assertFalse(ASSERTION_FALSE_MESSAGE, PhoneNumbersUtil.isValidMobileNumber(null));
+        assertFalse(ASSERTION_FALSE_MESSAGE, PhoneNumbersUtil.isValidMobileNumber(UK_LAND_LINE));
+        assertFalse(ASSERTION_FALSE_MESSAGE, PhoneNumbersUtil.isValidMobileNumber(UK_LAND_LINE_WITH_COUNTRY_CODE));
+    }
+
+    @Test
+    public void isValidUkMobileNumberWillBeTrueForValidUkMobileNumbers() {
+        assertTrue(ASSERTION_TRUE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber(UK_MOBILE_NUMBER));
+        assertTrue(ASSERTION_TRUE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber(UK_MOBILE_NUMBER_WITH_COUNTRY_CODE));
+        assertTrue(ASSERTION_TRUE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber("07123456789"));
+        assertTrue(ASSERTION_TRUE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber("07123 456789"));
+        assertTrue(ASSERTION_TRUE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber("07123 456 789"));
+        assertTrue(ASSERTION_TRUE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber("+447123456789"));
+        assertTrue(ASSERTION_TRUE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber("+44 7123 456 789"));
+    }
+
+    @Test
+    public void isValidUkMobileNumberWillBeFalseForLandLineNumbers() {
+        assertFalse(ASSERTION_FALSE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber(UK_LAND_LINE));
+        assertFalse(ASSERTION_FALSE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber(UK_LAND_LINE_WITH_COUNTRY_CODE));
+        assertFalse(ASSERTION_FALSE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber("01234567890"));
+        assertFalse(ASSERTION_FALSE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber("08001234567"));
+    }
+
+    @Test
+    public void isValidUkMobileNumberWillReturnFalseForInvalidValues() {
+        assertFalse(ASSERTION_FALSE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber("0744"));
+        assertFalse(ASSERTION_FALSE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber(null));
+        assertFalse(ASSERTION_FALSE_MESSAGE, PhoneNumbersUtil.isValidUkMobileNumber(""));
+    }
+
+    @Test
+    public void isValidLandLineNumberReturnsTrueForLandlineNumbers() {
+        assertTrue(ASSERTION_TRUE_MESSAGE, PhoneNumbersUtil.isValidLandLineNumber(US_LAND_LINE_WITH_COUNTRY_CODE));
+        assertTrue(ASSERTION_TRUE_MESSAGE, PhoneNumbersUtil.isValidLandLineNumber(UK_LAND_LINE));
+    }
+
+    @Test
+    public void cleanNumberTestForUkMobile() {
+        assertEquals(ASSERTION_EQUALS_MESSAGE, "+447861675377", PhoneNumbersUtil.cleanPhoneNumber(UK_MOBILE_NUMBER));
+    }
+
+    @Test
+    public void cleanNumberTestForUkLandLine() {
+        assertEquals(ASSERTION_EQUALS_MESSAGE, "+442037374299", PhoneNumbersUtil.cleanPhoneNumber(UK_LAND_LINE));
+    }
+
+    @Test
+    public void cleanNumberTestForUkLandLineWithCountryCode() {
+        assertEquals(ASSERTION_EQUALS_MESSAGE, "+442037374299", PhoneNumbersUtil.cleanPhoneNumber(UK_LAND_LINE_WITH_COUNTRY_CODE));
+    }
+
+    @Test
+    public void cleanNumberTestForAnAmericanLandLine() {
+        assertEquals(ASSERTION_EQUALS_MESSAGE, "+15417543010", PhoneNumbersUtil.cleanPhoneNumber(US_LAND_LINE_WITH_COUNTRY_CODE));
+    }
+}


### PR DESCRIPTION
Check for mobile number, land line number and a valid uk mobile number.

There is a requirement to check for a valid uk mobile number in the notification service and case loaded.

There is an additional requirement (SSCS-4658) to send notifications to representatives when they give a valid mobile number - hence the need for a common component to handle this duplicated logic.

This PR uses the library @keefmarshall has identified to handle validation of phone numbers (https://github.com/googlei18n/libphonenumber)