### PR TITLE
Appointees to sign in with surname only

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/CcdService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/CcdService.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.sscs.ccd.service;
 
-import static gcardone.junidecode.Junidecode.unidecode;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.SUBSCRIPTION_UPDATED;
 
 import com.google.common.collect.ImmutableMap;
@@ -16,6 +15,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.Subscriptions;
 import uk.gov.hmcts.reform.sscs.ccd.exception.AppealNotFoundException;
 import uk.gov.hmcts.reform.sscs.ccd.exception.CcdException;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
+import uk.gov.hmcts.reform.sscs.utility.SurnameUtil;
 
 @Service
 @Slf4j
@@ -139,7 +139,7 @@ public class CcdService {
                 && caseData.getAppeal().getAppellant().getName() != null
                 && caseData.getAppeal().getAppellant().getName().getLastName() != null
                 && caseData.getSubscriptions().getAppellantSubscription().getTya().equals(appealNumber)
-                && compareSurnames(surname, caseData.getAppeal().getAppellant().getName().getLastName());
+                && SurnameUtil.compare(surname, caseData.getAppeal().getAppellant().getName().getLastName());
     }
 
     private boolean doesMatchRepresentativeAppealNumberAndLastname(String surname, SscsCaseData caseData, String appealNumber) {
@@ -147,7 +147,7 @@ public class CcdService {
                 && caseData.getAppeal().getRep().getName() != null
                 && caseData.getAppeal().getRep().getName().getLastName() != null
                 && caseData.getSubscriptions().getRepresentativeSubscription().getTya().equals(appealNumber)
-                && compareSurnames(surname, caseData.getAppeal().getRep().getName().getLastName());
+                && SurnameUtil.compare(surname, caseData.getAppeal().getRep().getName().getLastName());
     }
 
     private SscsCaseDetails getCaseByAppealNumber(String appealNumber, IdamTokens idamTokens) {
@@ -170,13 +170,6 @@ public class CcdService {
     private List<SscsCaseDetails> getSscsCaseDetailsByRepresentativeAppealNumber(String appealNumber, IdamTokens idamTokens) {
         return searchCcdCaseService.findCaseBySearchCriteria(ImmutableMap.of(
                 "case.subscriptions.representativeSubscription.tya", appealNumber), idamTokens);
-    }
-
-    private boolean compareSurnames(String surname, String caseDataLastName) {
-        String caseDataSurname = unidecode(caseDataLastName)
-                .replaceAll("[^a-zA-Z]", "");
-        String unidecodeSurname = unidecode(surname).replaceAll("[^a-zA-Z]", "");
-        return caseDataSurname.equalsIgnoreCase(unidecodeSurname);
     }
 
     private CcdException logCcdException(String message, Exception ex) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/utility/SurnameUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/utility/SurnameUtil.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.sscs.utility;
+
+import static gcardone.junidecode.Junidecode.unidecode;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class SurnameUtil {
+
+    private SurnameUtil() { }
+
+    public static boolean compare(String surname, String caseDataLastName) {
+
+        String normalizedSurname = normalizeSurname(surname);
+        String normalizedCaseDataSurname = normalizeSurname(caseDataLastName);
+
+        return normalizedSurname.equals(normalizedCaseDataSurname);
+    }
+
+    private static String normalizeSurname(String surname) {
+
+        return unidecode(removeBracketedAppointee(surname).toLowerCase())
+                .replaceAll("[^a-zA-Z]", "");
+    }
+
+    private static String removeBracketedAppointee(String surname) {
+
+        Pattern pattern = Pattern.compile("\\(.*appointee.*\\)");
+        Matcher matcher = pattern.matcher(surname.toLowerCase());
+        return matcher.replaceFirst("");
+    }
+
+
+}
+

--- a/src/test/java/uk/gov/hmcts/reform/sscs/utility/SurnameUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/utility/SurnameUtilTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.sscs.utility;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 public class SurnameUtilTest {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/utility/SurnameUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/utility/SurnameUtilTest.java
@@ -1,0 +1,79 @@
+package uk.gov.hmcts.reform.sscs.utility;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SurnameUtilTest {
+
+    @Test
+    public void shouldMatchIfFollowedByBracketedAppointee() {
+        Assert.assertTrue(SurnameUtil.compare("Smith", "Smith (Appointee)"));
+        Assert.assertTrue(SurnameUtil.compare("Smith", "Smith (appointee)"));
+        Assert.assertTrue(SurnameUtil.compare("Smith", "Smith ( Appointee)"));
+        Assert.assertTrue(SurnameUtil.compare("Smith", "Smith ( appointee)"));
+        Assert.assertTrue(SurnameUtil.compare("Smith", "Smith (Appointee )"));
+        Assert.assertTrue(SurnameUtil.compare("Smith", "Smith (appointee )"));
+        Assert.assertTrue(SurnameUtil.compare("Smith", "Smith ( Appointee )"));
+        Assert.assertTrue(SurnameUtil.compare("Smith", "Smith ( appointee )"));
+        Assert.assertTrue(SurnameUtil.compare("Smith", "Smith(Appointee)"));
+        Assert.assertTrue(SurnameUtil.compare("Smith", "Smith(appointee)"));
+        Assert.assertTrue(SurnameUtil.compare("Smith (Appointee)", "Smith"));
+        Assert.assertTrue(SurnameUtil.compare("Smith (appointee)", "Smith"));
+        Assert.assertTrue(SurnameUtil.compare("Smith ( Appointee)", "Smith"));
+        Assert.assertTrue(SurnameUtil.compare("Smith ( appointee)", "Smith"));
+        Assert.assertTrue(SurnameUtil.compare("Smith (Appointee )", "Smith"));
+        Assert.assertTrue(SurnameUtil.compare("Smith (appointee )", "Smith"));
+        Assert.assertTrue(SurnameUtil.compare("Smith ( Appointee ) ", "Smith"));
+        Assert.assertTrue(SurnameUtil.compare("Smith ( appointee )", "Smith"));
+        Assert.assertTrue(SurnameUtil.compare("Smith(Appointee)", "Smith"));
+        Assert.assertTrue(SurnameUtil.compare("Smith(appointee)", "Smith"));
+    }
+
+    @Test
+    public void shouldNotMatchIfFollowedByBracketedContentThatIsNotAppointee() {
+        Assert.assertFalse(SurnameUtil.compare("Smith", "Smith (abcdedf)"));
+        Assert.assertFalse(SurnameUtil.compare("Smith", "Smith ( abcdedf)"));
+        Assert.assertFalse(SurnameUtil.compare("Smith", "Smith ( abcdedf)"));
+        Assert.assertFalse(SurnameUtil.compare("Smith", "Smith (abcdedf )"));
+        Assert.assertFalse(SurnameUtil.compare("Smith", "Smith ( abcdedf )"));
+        Assert.assertFalse(SurnameUtil.compare("Smith", "Smith (  abcdedf)"));
+        Assert.assertFalse(SurnameUtil.compare("Smith", "Smith(abcdedf)"));
+        Assert.assertFalse(SurnameUtil.compare("Smith", "Smith( abcdedf )"));
+    }
+
+    @Test
+    public void shouldNotMatchIfSurnamesAreDifferent() {
+        Assert.assertFalse(SurnameUtil.compare("Smith", "Jones"));
+        Assert.assertFalse(SurnameUtil.compare("Smith", "Jones (Appointee)"));
+        Assert.assertFalse(SurnameUtil.compare("Smith (Appointee)", "Smythe"));
+    }
+
+    @Test
+    public void shouldMatchIfTheSurnameIsActuallyAppointee() {
+        Assert.assertTrue(SurnameUtil.compare("Appointee", "appointee"));
+        Assert.assertTrue(SurnameUtil.compare("Appointee", "Appointee (Appointee)"));
+    }
+
+    @Test
+    public void shouldIgnoreCaseAndSpaces() {
+        Assert.assertTrue(SurnameUtil.compare("Smith", " smith"));
+        Assert.assertTrue(SurnameUtil.compare("Smith", " smith "));
+        Assert.assertTrue(SurnameUtil.compare("smith", "SMITH "));
+    }
+
+    @Test
+    public void shouldIgnoreAccents() {
+        Assert.assertTrue(SurnameUtil.compare("Tést", " test"));
+        Assert.assertTrue(SurnameUtil.compare("Test", " Tést "));
+        Assert.assertTrue(SurnameUtil.compare("smíth", "SMITH "));
+
+        Assert.assertFalse(SurnameUtil.compare("smíth", "SMITHé "));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldFailOnNull() {
+        SurnameUtil.compare(null, null);
+    }
+
+}


### PR DESCRIPTION
Moved the surname comparison logic out of a private method in the CcdService into a dedicated utility class and added logic to ignore (appointee) and its variants as per

https://tools.hmcts.net/jira/browse/SSCS-4820