### PR TITLE
SSCS-4605 Update hearing type when relisting hearing

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Address.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Address.java
@@ -9,7 +9,7 @@ import org.apache.commons.lang.StringUtils;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-@Builder
+@Builder(toBuilder = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Address {
     private String line1;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Appeal.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Appeal.java
@@ -7,7 +7,7 @@ import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class Appeal {
     private MrnDetails mrnDetails;
     private Appellant appellant;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/AppealReason.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/AppealReason.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class AppealReason {
     private AppealReasonDetails value;
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/AppealReasonDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/AppealReasonDetails.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class AppealReasonDetails {
     private String reason;
     private String description;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/AppealReasons.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/AppealReasons.java
@@ -10,7 +10,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AppealReasons {
     private List<AppealReason> reasons;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Appellant.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Appellant.java
@@ -8,7 +8,7 @@ import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class Appellant {
 
     private Name name;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Appointee.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Appointee.java
@@ -8,7 +8,7 @@ import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class Appointee {
 
     private Name name;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/BenefitType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/BenefitType.java
@@ -8,7 +8,7 @@ import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class BenefitType {
     private String code;
     private String description;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Contact.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Contact.java
@@ -8,7 +8,7 @@ import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class Contact {
     private String email;
     private String phone;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/CorDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/CorDocument.java
@@ -9,7 +9,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CorDocument {
     private CorDocumentDetails value;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/CorDocumentDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/CorDocumentDetails.java
@@ -9,7 +9,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CorDocumentDetails {
     private SscsDocumentDetails document;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DateRange.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DateRange.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class DateRange {
     private String start;
     private String end;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Document.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class Document implements Comparable<Document> {
     private DocumentDetails value;
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DocumentDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DocumentDetails.java
@@ -10,7 +10,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class DocumentDetails {
     private String dateReceived;
     private String evidenceType;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DocumentLink.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DocumentLink.java
@@ -9,7 +9,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DocumentLink {
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DwpTimeExtension.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DwpTimeExtension.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class DwpTimeExtension {
     private DwpTimeExtensionDetails value;
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DwpTimeExtensionDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DwpTimeExtensionDetails.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class DwpTimeExtensionDetails {
     private String requested;
     private String granted;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Event.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class Event implements Comparable<Event> {
     EventDetails value;
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
@@ -28,7 +28,8 @@ public enum EventType {
     FINAL_HEARING_HOLDING_REMINDER("finalHearingHoldingReminder", 0, true),
     HEARING_REMINDER("hearingReminder", 0, true),
     NON_COMPLIANT("nonCompliant", 0, true),
-    INCOMPLETE_APPLICATION_RECEIVED("incompleteApplicationReceived", 0, true);
+    INCOMPLETE_APPLICATION_RECEIVED("incompleteApplicationReceived", 0, true),
+    UPDATE_HEARING_TYPE("updateHearingType", 0, false);
 
     private String type;
     private String ccdType;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Evidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Evidence.java
@@ -10,7 +10,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Evidence {
     private List<Document> documents;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/ExcludeDate.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/ExcludeDate.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class ExcludeDate {
     private DateRange value;
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Hearing.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Hearing.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class Hearing implements Comparable<Hearing> {
     private HearingDetails value;
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/HearingDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/HearingDetails.java
@@ -12,7 +12,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class HearingDetails {
     private Venue venue;
     private String hearingDate;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/HearingOptions.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/HearingOptions.java
@@ -7,7 +7,7 @@ import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-@Builder
+@Builder(toBuilder = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class HearingOptions {
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Identity.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Identity.java
@@ -8,7 +8,7 @@ import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class Identity {
     private String dob;
     private String nino;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/MrnDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/MrnDetails.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class MrnDetails {
     private String dwpIssuingOffice;
     private String mrnDate;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Name.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Name.java
@@ -9,7 +9,7 @@ import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class Name {
     private String title;
     private String firstName;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/OnlinePanel.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/OnlinePanel.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class OnlinePanel {
     private String assignedTo;
     private String medicalMember;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/RegionalProcessingCenter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/RegionalProcessingCenter.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Value;
 
 @Value
-@Builder
+@Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RegionalProcessingCenter {
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Representative.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Representative.java
@@ -8,7 +8,7 @@ import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class Representative {
 
     private String hasRepresentative;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseDetails.java
@@ -7,7 +7,7 @@ import lombok.Data;
 import uk.gov.hmcts.reform.ccd.client.model.Classification;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SscsCaseDetails {
     private Long id;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsDocument.java
@@ -9,7 +9,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SscsDocument {
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsDocumentDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsDocumentDetails.java
@@ -9,7 +9,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SscsDocumentDetails {
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Venue.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Venue.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class Venue {
     private String name;
     private Address address;


### PR DESCRIPTION
We want to modify the hearing type when re relist an appeal from cor to
oral. This was hard before as we would of had to recreate the entire
SscsDocument. Added toBuilder=true to all the objects this allows us to
create a builder from the current state of an object.

Added new EventType UPDATE_HEARING_TYPE for this event.