### PR TITLE
Allow appointee surname search for TYA

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/CcdService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/CcdService.java
@@ -153,7 +153,8 @@ public class CcdService {
         SscsCaseData caseData = (SscsCaseData) details.getData();
         caseData.setCcdCaseId(String.valueOf(details.getId()));
         return (doesMatchAppellantAppealNumberAndLastname(surname, caseData, appealNumber)
-                || doesMatchRepresentativeAppealNumberAndLastname(surname, caseData, appealNumber)) ? caseData : null;
+                || doesMatchRepresentativeAppealNumberAndLastname(surname, caseData, appealNumber)
+                || doesMatchAppointeeAppealNumberAndLastname(surname, caseData, appealNumber)) ? caseData : null;
     }
 
     private boolean doesMatchAppellantAppealNumberAndLastname(String surname, SscsCaseData caseData, String appealNumber) {
@@ -171,6 +172,15 @@ public class CcdService {
                 && appealNumber.equals(caseData.getSubscriptions().getRepresentativeSubscription().getTya())
                 && SurnameUtil.compare(surname, caseData.getAppeal().getRep().getName().getLastName());
     }
+
+    private boolean doesMatchAppointeeAppealNumberAndLastname(String surname, SscsCaseData caseData, String appealNumber) {
+        return caseData.getAppeal() != null && caseData.getAppeal().getAppellant().getAppointee() != null
+                && caseData.getAppeal().getAppellant().getAppointee().getName() != null
+                && caseData.getAppeal().getAppellant().getAppointee().getName().getLastName() != null
+                && appealNumber.equals(caseData.getSubscriptions().getAppointeeSubscription().getTya())
+                && SurnameUtil.compare(surname, caseData.getAppeal().getAppellant().getAppointee().getName().getLastName());
+    }
+
 
     private SscsCaseDetails getCaseByAppealNumber(String appealNumber, IdamTokens idamTokens) {
         log.info("Finding case by appeal number {}", appealNumber);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/util/CaseDataUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/util/CaseDataUtils.java
@@ -240,6 +240,7 @@ public final class CaseDataUtils {
                 .appellantSubscription(appellantSubscription)
                 .supporterSubscription(supporterSubscription)
                 .representativeSubscription(representativeSubscription)
+                .appointeeSubscription(appointeeSubscription)
                 .build();
 
         RegionalProcessingCenter rpc = RegionalProcessingCenter.builder()

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/service/CcdServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/service/CcdServiceTest.java
@@ -36,6 +36,7 @@ public class CcdServiceTest {
 
     private static final String APPELLANT_APPEAL_NUMBER = "app-appeal-number";
     private static final String REPRESENTATIVE_APPEAL_NUMBER = "rep-appeal-number";
+    private static final String APPOINTEE_APPEAL_NUMBER = "appointee-appeal-number";
     private static final String UPDATED_TEST_COM = "updated@test.com";
     private static final String YES = "yes";
     private IdamTokens idamTokens;
@@ -61,6 +62,11 @@ public class CcdServiceTest {
     private final Map<String, String> representativeSearchCriteria = new HashMap<String, String>() {
         {
             put("case.subscriptions.representativeSubscription.tya", REPRESENTATIVE_APPEAL_NUMBER);
+        }
+    };
+    private final Map<String, String> appointeeSearchCriteria = new HashMap<String, String>() {
+        {
+            put("case.subscriptions.appointeeSubscription.tya", APPOINTEE_APPEAL_NUMBER);
         }
     };
     private final Map<String, String> searchCriteria = new HashMap<String, String>() {
@@ -329,6 +335,19 @@ public class CcdServiceTest {
                 .findCcdCaseByAppealNumberAndSurname(REPRESENTATIVE_APPEAL_NUMBER, "Giles", idamTokens);
 
         assertNotNull(sscsCaseData);
+    }
+
+    @Test
+    public void shouldReturnCaseGivenAppointeeSurnameAndAppealNumber() {
+        when(ccdClient.searchForCaseworker(idamTokens, appointeeSearchCriteria))
+                .thenReturn(singletonList(caseDetails));
+
+        SscsCaseData caseData = ccdService.findCcdCaseByAppealNumberAndSurname(
+                APPOINTEE_APPEAL_NUMBER, "Appointer", idamTokens);
+
+        assertNotNull(caseData);
+        assertEquals("Appointer", caseData.getAppeal().getAppellant().getAppointee().getName().getLastName());
+        assertEquals("1", caseData.getCcdCaseId());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-5232

### Change description ###
When searching for a case with a surname and an appeal number, include appointee in the search.
Only merge into master branch once ticket SSCS-5232 has been QAed. Then merge and tag.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
