### PR TITLE
SSCS-5306  fix incorrect rpc name lookup

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
@@ -21,6 +21,7 @@ public enum EventType {
     CLOSED("closed", "appealClosed", 12, false),
     DWP_RESPOND_OVERDUE("dwpRespondOverdue", "responseOverdue", 13, true),
     EVIDENCE_RECEIVED("evidenceReceived", "evidenceReceived", -1, true),
+    DRAFT("draft", "draft", 0, false),
     EVIDENCE_REMINDER("evidenceRemainder", "evidenceReminder", -2, true),
     SYA_APPEAL_CREATED("appealCreated", 0, true),
     SUBSCRIPTION_CREATED("subscriptionCreated", 0, true),

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
@@ -21,7 +21,6 @@ public enum EventType {
     CLOSED("closed", "appealClosed", 12, false),
     DWP_RESPOND_OVERDUE("dwpRespondOverdue", "responseOverdue", 13, true),
     EVIDENCE_RECEIVED("evidenceReceived", "evidenceReceived", -1, true),
-    DRAFT("draft", "draft", 0, false),
     EVIDENCE_REMINDER("evidenceRemainder", "evidenceReminder", -2, true),
     SYA_APPEAL_CREATED("appealCreated", 0, true),
     SUBSCRIPTION_CREATED("subscriptionCreated", 0, true),

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/RegionalProcessingCenterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/RegionalProcessingCenterService.java
@@ -98,21 +98,11 @@ public class RegionalProcessingCenterService {
     /**
      * Lookup by the name of the RPC. We should be getting rid of the above code to
      * get it from the SC Reference. Restructure the json file to work by just the name.
-     * @param name the RPC name
-     * @return RPC name
+     * @param name the RPC name e.g. "Birmingham"
+     * @return RPC object
      */
     public RegionalProcessingCenter getByName(String name) {
-        if (StringUtils.isBlank(name)) {
-            return null;
-        }
-
-        String regionalProcessingCenter = sccodeRegionalProcessingCentermap.get("SSCS " + name);
-
-        if (null != regionalProcessingCenter) {
-            return regionalProcessingCenterMap.get(regionalProcessingCenter);
-        } else {
-            return null;
-        }
+        return regionalProcessingCenterMap.get("SSCS " + name);
     }
 
     public Map<String, RegionalProcessingCenter> getRegionalProcessingCenterMap() {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/RegionalProcessingCenterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/RegionalProcessingCenterServiceTest.java
@@ -143,6 +143,10 @@ public class RegionalProcessingCenterServiceTest {
         assertNull("RPC Service getbyName() should have failed when venueID was used",
                     regionalProcessingCenterService.getByName(venueId));
 
+        String scCode = "SC024";
+        assertNull("RPC Service getbyName() should have failed when SC Code was used",
+                    regionalProcessingCenterService.getByName(scCode));
+                    
         String postCode = "B4 6BJ";
         assertNull("RPC Service getbyName() should have failed when postcode was used",
                     regionalProcessingCenterService.getByName(postCode));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/RegionalProcessingCenterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/RegionalProcessingCenterServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscs.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
@@ -125,6 +126,26 @@ public class RegionalProcessingCenterServiceTest {
 
         //Then
         assertBirminghamRpc(regionalProcessingCenter);
+    }
+
+    @Test
+    public void testGetRegionalProcessingCentreByName() {
+        regionalProcessingCenterService.init();
+
+        String birminghamVenueName = "Birmingham";
+        assertBirminghamRpc(regionalProcessingCenterService.getByName(birminghamVenueName));
+
+        String jsonKey = "SSCS Birmingham";
+        assertNull("RPC Service getbyName() should have failed when JSON key was used",
+                    regionalProcessingCenterService.getByName(jsonKey));
+
+        String venueId = "24";
+        assertNull("RPC Service getbyName() should have failed when venueID was used",
+                    regionalProcessingCenterService.getByName(venueId));
+
+        String postCode = "B4 6BJ";
+        assertNull("RPC Service getbyName() should have failed when postcode was used",
+                    regionalProcessingCenterService.getByName(postCode));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-5104


### Change description ###
Tribunal endpoint had a test which hardcoded an RPC into a record. I noticed that the code it was testing was just a wrapper to  SubmitYourAppealToCcdCaseDataDeserializer.convertSyaToCcdCaseData(), passing arguments with no alterations. I refactored it and tests failed because the original RegionalProcessingCenterService.getByName() could never return anything except nulls. This is because it used the SC RPC lookup where the keys are all like "SC123". Worse still it was prepending the name argument with "SSCS" so even if you gave it a valid venueID it would look for the key "SSCS SC123" which would also fail.
I fixed the method so that it would be able to use the correct Map object and make it possible to return something other than null.


**Does this PR introduce a breaking change?** (check one with "x")
Unknown at time of opening review. Testing other SSCS projects now...
```
[ ] Yes
[ ] No
```
