### PR TITLE
Added draft sscs documents and draft cor documents. 

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseData.java
@@ -25,7 +25,9 @@ public class SscsCaseData implements CaseData {
     private Subscriptions subscriptions;
     private RegionalProcessingCenter regionalProcessingCenter;
     private List<SscsDocument> sscsDocument;
+    private List<SscsDocument> draftSscsDocument;
     private List<CorDocument> corDocument;
+    private List<CorDocument> draftCorDocument;
     private String generatedNino;
     private String generatedSurname;
     private String generatedEmail;
@@ -50,7 +52,9 @@ public class SscsCaseData implements CaseData {
                         @JsonProperty("subscriptions") Subscriptions subscriptions,
                         @JsonProperty("regionalProcessingCenter") RegionalProcessingCenter regionalProcessingCenter,
                         @JsonProperty("sscsDocument") List<SscsDocument> sscsDocument,
+                        @JsonProperty("draftSscsDocument") List<SscsDocument> draftSscsDocument,
                         @JsonProperty("corDocument") List<CorDocument> corDocument,
+                        @JsonProperty("draftCorDocument") List<CorDocument> draftCorDocument,
                         @JsonProperty("generatedNino") String generatedNino,
                         @JsonProperty("generatedSurname") String generatedSurname,
                         @JsonProperty("generatedEmail") String generatedEmail,
@@ -72,7 +76,9 @@ public class SscsCaseData implements CaseData {
         this.subscriptions = subscriptions;
         this.regionalProcessingCenter = regionalProcessingCenter;
         this.sscsDocument = sscsDocument;
+        this.draftSscsDocument = draftSscsDocument;
         this.corDocument = corDocument;
+        this.draftCorDocument = draftCorDocument;
         this.generatedNino = generatedNino;
         this.generatedSurname = generatedSurname;
         this.generatedEmail = generatedEmail;


### PR DESCRIPTION
These will be hidden from the caseworkers so cannot be seen in CCD. The 
user can upload to them but only when they submit all their evidence 
should it be copied across to the main place evidence is stored. Then the 
caseworker will be able to see it in CCD.