### PR TITLE
Fixing a missing case id for the notifications service

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/SscsCcdConvertService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/SscsCcdConvertService.java
@@ -36,6 +36,9 @@ public class SscsCcdConvertService {
     }
 
     public SscsCaseDetails getCaseDetails(CaseDetails caseDetails) {
+        if (caseDetails.getId() != null) {
+            caseDetails.getData().put("ccdCaseId", caseDetails.getId().toString());
+        }
         return SscsCaseDetails.builder()
                 .id(caseDetails.getId())
                 .jurisdiction(caseDetails.getJurisdiction())

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/service/SscsCcdConvertServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/service/SscsCcdConvertServiceTest.java
@@ -2,11 +2,13 @@ package uk.gov.hmcts.reform.sscs.ccd.service;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static uk.gov.hmcts.reform.sscs.ccd.service.SscsCcdConvertService.hasAppellantIdentify;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.junit.Test;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Appellant;
@@ -161,5 +163,31 @@ public class SscsCcdConvertServiceTest {
         SscsCaseDetails caseDetails = new SscsCcdConvertService().getCaseDetails(build);
 
         assertTrue(hasAppellantIdentify(caseDetails.getData()));
+    }
+
+    @Test
+    public void testBuilderMissingCaseId() {
+        Long caseId = 1001L;
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("caseReference", "SC924/39/23210");
+
+        uk.gov.hmcts.reform.ccd.client.model.CaseDetails caseDetails = CaseDetails.builder().id(caseId)
+                .data(data)
+                .build();
+
+        assertEquals(caseId.toString(), new SscsCcdConvertService().getCaseDetails(caseDetails).getData().getCcdCaseId());
+    }
+
+    @Test
+    public void testBuilderNullCaseId() {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("caseReference", "SC924/39/23210");
+
+        uk.gov.hmcts.reform.ccd.client.model.CaseDetails caseDetails = CaseDetails.builder()
+                .data(data)
+                .build();
+
+        assertNull(new SscsCcdConvertService().getCaseDetails(caseDetails).getData().getCcdCaseId());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-6190


### Change description ###
Fixing a bug where notifications are expecting a case id to be populated and its not


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
