### PR TITLE
SSCS-6669 - add DirectionType

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DirectionType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DirectionType.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.sscs.ccd.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum DirectionType {
+
+    @JsonProperty("appealToProceed")
+    APPEAL_TO_PROCEED("appealToProceed"),
+
+    @JsonProperty("provideInformation")
+    PROVIDE_INFORMATION("provideInformation");
+
+    // needed only for the toString method
+    private final String id;
+
+    DirectionType(String id) {
+        this.id = id;
+    }
+
+    // todo: get rid of the need to override toString as READ_ENUMS_USING_TO_STRING is enabled in other projects (i.e. remove READ_ENUMS_USING_TO_STRING)
+    @Override
+    public String toString() {
+        return id;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseData.java
@@ -25,6 +25,7 @@ public class SscsCaseData implements CaseData {
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String ccdCaseId;
 
+    private State state;
     private String caseReference;
     private String caseCreated;
     private InfoRequests infoRequests;
@@ -112,6 +113,7 @@ public class SscsCaseData implements CaseData {
 
     @JsonCreator
     public SscsCaseData(@JsonProperty(value = "ccdCaseId", access = JsonProperty.Access.WRITE_ONLY) String ccdCaseId,
+                        @JsonProperty(value = "state") State state,
                         @JsonProperty("caseReference") String caseReference,
                         @JsonProperty("caseCreated") String caseCreated,
                         @JsonProperty("infoRequests") InfoRequests infoRequests,
@@ -196,6 +198,7 @@ public class SscsCaseData implements CaseData {
                         @JsonProperty("directionType") DirectionType directionType
     ) {
         this.ccdCaseId = ccdCaseId;
+        this.state = state;
         this.caseReference = caseReference;
         this.caseCreated = caseCreated;
         this.infoRequests = infoRequests;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseData.java
@@ -108,6 +108,7 @@ public class SscsCaseData implements CaseData {
     private String dwpResponseDate;
     private String linkedCasesBoolean;
     private String decisionType;
+    private DirectionType directionType;
 
     @JsonCreator
     public SscsCaseData(@JsonProperty(value = "ccdCaseId", access = JsonProperty.Access.WRITE_ONLY) String ccdCaseId,
@@ -191,7 +192,8 @@ public class SscsCaseData implements CaseData {
                         @JsonProperty("dwpResponseDocument") DwpResponseDocument dwpResponseDocument,
                         @JsonProperty("dwpResponseDate") String dwpResponseDate,
                         @JsonProperty("linkedCasesBoolean") String linkedCasesBoolean,
-                        @JsonProperty("decisionType") String decisionType
+                        @JsonProperty("decisionType") String decisionType,
+                        @JsonProperty("directionType") DirectionType directionType
     ) {
         this.ccdCaseId = ccdCaseId;
         this.caseReference = caseReference;
@@ -273,6 +275,7 @@ public class SscsCaseData implements CaseData {
         this.dwpResponseDate = dwpResponseDate;
         this.linkedCasesBoolean = linkedCasesBoolean;
         this.decisionType = decisionType;
+        this.directionType = directionType;
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/State.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/State.java
@@ -44,6 +44,24 @@ public enum State {
     @JsonProperty("withDwp")
     WITH_DWP("withDwp"),
 
+    @JsonProperty("closed")
+    CLOSED("closed"),
+
+    @JsonProperty("draft")
+    DRAFT("draft"),
+
+    @JsonProperty("draftArchived")
+    DRAFT_ARCHIVED("draftArchived"),
+
+    @JsonProperty("hearing")
+    HEARING("hearing"),
+
+    @JsonProperty("outcome")
+    OUTCOME("outcome"),
+
+    @JsonProperty("pendingAppeal")
+    PENDING_APPEAL("pendingAppeal"),
+
     @JsonProperty("unknown")
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/State.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/State.java
@@ -1,23 +1,50 @@
 package uk.gov.hmcts.reform.sscs.ccd.domain;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum State {
 
+    @JsonProperty("appealCreated")
     APPEAL_CREATED("appealCreated"),
+
+    @JsonProperty("testCreate")
     TEST_CREATE("testCreate"),
+
+    @JsonProperty("incompleteApplication")
     INCOMPLETE_APPLICATION("incompleteApplication"),
+
+    @JsonProperty("interlocutoryReviewState")
     INTERLOCUTORY_REVIEW_STATE("interlocutoryReviewState"),
+
+    @JsonProperty("incompleteApplicationVoidState")
     INCOMPLETE_APPLICATION_VOID_STATE("incompleteApplicationVoidState"),
+
+    @JsonProperty("incompleteApplicationInformationReqsted")
     INCOMPLATE_APPLICATION_INFORMATION_REQUESTED("incompleteApplicationInformationReqsted"),
+
+    @JsonProperty("voidState")
     VOID_STATE("voidState"),
+
+    @JsonProperty("withdrawnRevisedStruckOutLapsedState")
     WITHDRAWN_REVISED_STRUCK_OUT_LAPSED_STATE("withdrawnRevisedStruckOutLapsedState"),
+
+    @JsonProperty("dormantAppealState")
     DORMANT_APPEAL_STATE("dormantAppealState"),
+
+    @JsonProperty("validAppeal")
     VALID_APPEAL("validAppeal"),
+
+    @JsonProperty("responseReceived")
     RESPONSE_RECEIVED("responseReceived"),
+
+    @JsonProperty("readyToList")
     READY_TO_LIST("readyToList"),
+
+    @JsonProperty("withDwp")
     WITH_DWP("withDwp"),
 
+    @JsonProperty("unknown")
     @JsonEnumDefaultValue
     UNKNOWN("unknown");
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/StateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/StateTest.java
@@ -1,13 +1,10 @@
 package uk.gov.hmcts.reform.sscs.ccd.domain;
 
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
-import java.util.NoSuchElementException;
 import java.util.Optional;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.Test;
 
 public class StateTest {
     // copied from the State TAB in the CCD Definition file

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/StateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/StateTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.sscs.ccd.domain;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class StateTest {
+    // copied from the State TAB in the CCD Definition file
+    private static final String ALL_STATES = "appealCreated\n" +
+            "closed\n" +
+            "dormantAppealState\n" +
+            "draft\n" +
+            "draftArchived\n" +
+            "hearing\n" +
+            "incompleteApplication\n" +
+            "incompleteApplicationInformationReqsted\n" +
+            "interlocutoryReviewState\n" +
+            "outcome\n" +
+            "pendingAppeal\n" +
+            "readyToList\n" +
+            "responseReceived\n" +
+            "testCreate\n" +
+            "validAppeal\n" +
+            "incompleteApplicationVoidState\n" +
+            "voidState\n" +
+            "withDwp";
+
+    @Test
+    public void hasAllStatesDefinedInCcdDefinitionFile() {
+        String[] allStateIds = ALL_STATES.split("\n");
+        State[] allStatesActual = State.values();
+
+        for (String stateId : allStateIds) {
+            final Optional<State> found = Arrays.stream(allStatesActual).filter(s -> s.getId().contains(stateId)).findFirst();
+            assertTrue(String.format("missing %s", stateId), found.isPresent());
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/service/SscsCcdConvertServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/service/SscsCcdConvertServiceTest.java
@@ -12,10 +12,7 @@ import java.util.Map;
 
 import org.junit.Test;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Appellant;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Identity;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.ccd.service.SscsCcdConvertService;
 
 public class SscsCcdConvertServiceTest {
@@ -227,5 +224,22 @@ public class SscsCcdConvertServiceTest {
         assertTrue(hasAppellantIdentify(caseDetails.getData()));
 
         assertEquals(LocalDate.of(2019, 07, 04), caseDetails.getData().getSscsInterlocDirectionDocument().getDocumentDateAdded());
+    }
+
+    @Test
+    public void canTranslateAnEnum() {
+        String caseReference = "caseRef";
+        HashMap<String, Object> data = new HashMap<>();
+        data.put("caseReference", caseReference);
+        data.put("directionType", DirectionType.APPEAL_TO_PROCEED);
+
+        long id = 123L;
+        CaseDetails build = CaseDetails.builder()
+                .id(id)
+                .data(data)
+                .build();
+        SscsCaseDetails caseDetails = new SscsCcdConvertService().getCaseDetails(build);
+
+        assertEquals(DirectionType.APPEAL_TO_PROCEED, caseDetails.getData().getDirectionType());
     }
 }


### PR DESCRIPTION
Add "Appeal to proceed" and "Provide information" as a "Direction Type" in the "Issue Direction" event