### PR TITLE
SSCS-7668 Adding writeFinalDecisionGenerateNotice attribute - needed for correct validation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseData.java
@@ -148,6 +148,7 @@ public class SscsCaseData implements CaseData {
     private String bundleConfiguration;
     //Final decision notice fields
     private String writeFinalDecisionIsDescriptorFlow;
+    private String writeFinalDecisionGenerateNotice;
     private String writeFinalDecisionAllowedOrRefused;
     private String writeFinalDecisionTypeOfHearing;
     private String writeFinalDecisionPresentingOfficerAttendedQuestion;
@@ -306,6 +307,7 @@ public class SscsCaseData implements CaseData {
                         @JsonProperty("bundleConfiguration") String bundleConfiguration,
                         @JsonProperty("writeFinalDecisionIsDescriptorFlow") String writeFinalDecisionIsDescriptorFlow,
                         @JsonProperty("writeFinalDecisionAllowedOrRefused") String writeFinalDecisionAllowedOrRefused,
+                        @JsonProperty("writeFinalDecisionGenerateNotice") String writeFinalDecisionGenerateNotice,
                         @JsonProperty("writeFinalDecisionTypeOfHearing") String writeFinalDecisionTypeOfHearing,
                         @JsonProperty("writeFinalDecisionPresentingOfficerAttendedQuestion") String writeFinalDecisionPresentingOfficerAttendedQuestion,
                         @JsonProperty("writeFinalDecisionAppellantAttendedQuestion") String writeFinalDecisionAppellantAttendedQuestion,
@@ -455,6 +457,7 @@ public class SscsCaseData implements CaseData {
         this.timeExtensionRequested = timeExtensionRequested;
         this.bundleConfiguration = bundleConfiguration;
         this.writeFinalDecisionIsDescriptorFlow = writeFinalDecisionIsDescriptorFlow;
+        this.writeFinalDecisionGenerateNotice = writeFinalDecisionGenerateNotice;
         this.writeFinalDecisionAllowedOrRefused = writeFinalDecisionAllowedOrRefused;
         this.writeFinalDecisionTypeOfHearing = writeFinalDecisionTypeOfHearing;
         this.writeFinalDecisionPresentingOfficerAttendedQuestion = writeFinalDecisionPresentingOfficerAttendedQuestion;


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-7668

### Change description ###

The business logic and validation for the manual upload route needs to know whether generate notice has been selected - this PR adds that attribute to SscsCaseData

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
