### PR TITLE
SSCS-7730 - Correctly serialise EventType

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,7 @@ dependencies {
     testCompile group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
     testCompile group: 'org.springframework', name: 'spring-test', version: '5.2.7.RELEASE'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.16.1'
+    testCompile group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.0'
     testCompile 'pl.pragmatists:JUnitParams:1.1.1'
 
     testCompileOnly 'org.projectlombok:lombok:1.18.10'

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscs.ccd.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.CaseFormat;
 import java.util.Arrays;
 
@@ -168,6 +169,7 @@ public enum EventType {
         return type;
     }
 
+    @JsonValue
     public String getCcdType() {
         return ccdType;
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/deserialisation/SscsCaseCallbackDeserializerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/deserialisation/SscsCaseCallbackDeserializerTest.java
@@ -26,6 +26,7 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +35,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.domain.DirectionResponse;
@@ -241,5 +244,19 @@ public class SscsCaseCallbackDeserializerTest {
         assertEquals("AdditionalEvidence.pdf", directionResponse.getDirectionResponses().get(0).getValue().getDocumentLink().getDocumentFilename());
         assertEquals("http://dm-store:4506/documents/5f574d09-1590-446e-bc02-1f2437688390", directionResponse.getDirectionResponses().get(0).getValue().getDocumentLink().getDocumentUrl());
         assertEquals("http://dm-store:4506/documents/5f574d09-1590-446e-bc02-1f2437688390/binary", directionResponse.getDirectionResponses().get(0).getValue().getDocumentLink().getDocumentBinaryUrl());
+    }
+
+    @Test
+    @Parameters({"adminAppealWithdrawnCallback.json", "updateFurtherEvidence.json"})
+    public void should_deserialise_and_serialise(final String jsonFileName) throws IOException, JSONException {
+        sscsCaseCallbackDeserializer = new SscsCaseCallbackDeserializer(mapper);
+
+        String path = getClass().getClassLoader().getResource(jsonFileName).getFile();
+        String json = FileUtils.readFileToString(new File(path), StandardCharsets.UTF_8.name());
+        Callback<SscsCaseData> actualSscsCaseCallback = sscsCaseCallbackDeserializer.deserialize(json);
+
+        String valueAsString = mapper.writeValueAsString(actualSscsCaseCallback);
+
+        JSONAssert.assertEquals(valueAsString, json,  JSONCompareMode.LENIENT);
     }
 }

--- a/src/test/resources/updateFurtherEvidence.json
+++ b/src/test/resources/updateFurtherEvidence.json
@@ -1111,5 +1111,5 @@
     }
   },
   "event_id": "directionIssued",
-  "ignore_warning": null
+  "ignore_warning": false
 }


### PR DESCRIPTION
When serialising a `Callback<SscsCaseData>`, the `EventType` does not get serialised correctly.

It should be:
`"event_id":"directionIssued",`
rather than
`"event_id":"DIRECTION_ISSUED",`
