### PR TITLE
SSCS-8034 Moving StringUtils from tribunals to common so it can be used by bulk loader

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/utility/StringUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/utility/StringUtils.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.sscs.utility;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class StringUtils {
+
+    private StringUtils() {
+        //
+    }
+
+    public static String getGramaticallyJoinedStrings(List<String> strings) {
+        StringBuilder result = new StringBuilder();
+        if (strings.size() == 1) {
+            return strings.get(0);
+        } else if (strings.size() > 1) {
+            result.append(strings.subList(0, strings.size() - 1)
+                .stream().collect(Collectors.joining(", ")));
+            result.append(" and ");
+            result.append(strings.get(strings.size() - 1));
+        }
+        return result.toString();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/utility/StringUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/utility/StringUtilsTest.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.sscs.utility;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    public void testEmptyList() {
+        String result = StringUtils.getGramaticallyJoinedStrings(new ArrayList<>());
+        Assert.assertEquals("", result);
+    }
+
+    @Test
+    public void testSingleValuedList() {
+        String result = StringUtils.getGramaticallyJoinedStrings(Arrays.asList("one"));
+        Assert.assertEquals("one", result);
+    }
+
+    @Test
+    public void testTwoValuesInList() {
+        String result = StringUtils.getGramaticallyJoinedStrings(Arrays.asList("one", "two"));
+        Assert.assertEquals("one and two", result);
+    }
+
+    @Test
+    public void testThreeValuesInList() {
+        String result = StringUtils.getGramaticallyJoinedStrings(Arrays.asList("one", "two", "three"));
+        Assert.assertEquals("one, two and three", result);
+    }
+
+    @Test
+    public void testFourValuesInList() {
+        String result = StringUtils.getGramaticallyJoinedStrings(Arrays.asList("one", "two", "three", "four"));
+        Assert.assertEquals("one, two, three and four", result);
+    }
+
+}


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-8034

### Change description ###

* Moving StringUtils from tribunals to common so it can be used by bulk loader


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
