### PR TITLE
SSCS-8351 - Notification - Adjournment notice Welsh translations

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
@@ -150,6 +150,7 @@ public enum EventType {
     REISSUE_DOCUMENT("reissueDocument", 0, false),
     ADJOURN_CASE("adjournCase", 0, false),
     ISSUE_ADJOURNMENT_NOTICE("issueAdjournmentNotice", 0, false),
+    ISSUE_ADJOURNMENT_NOTICE_WELSH("issueAdjournmentNoticeWelsh", 0, false),
     NOT_LISTABLE("notListable", 0, false),
     UPDATE_NOT_LISTABLE("updateNotListable", 0, false),
     UPLOAD_WELSH_DOCUMENT("uploadWelshDocument", 0, false),

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventTypeTest.java
@@ -139,6 +139,7 @@ public class EventTypeTest {
             "createWelshNotice\n" +
             "markDocumentsForTranslation\n" +
             "jointPartyAdded\n" +
+            "issueAdjournmentNoticeWelsh\n" +
             "abateCase\n" +
             "provideAppointeeDetails\n" +
             "deathOfAppellant";


### PR DESCRIPTION
SSCS-8351 - Notification - Adjournment notice Welsh translations

This PR adds a new event ISSUE_ADJOURNMENT_NOTICE_WELSH that when triggered will send the welsh Adjournment notice