### PR TITLE
SSCS-9677-add original sender to audioVideoEvidence

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/AbstractDocumentDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/AbstractDocumentDetails.java
@@ -28,6 +28,7 @@ public class AbstractDocumentDetails {
     private SscsDocumentTranslationStatus documentTranslationStatus;
     private DocumentLink resizedDocumentLink;
     private DocumentLink avDocumentLink;
+    private String originalPartySender;
 
     @JsonCreator
     public AbstractDocumentDetails(@JsonProperty("documentType") String documentType,
@@ -42,7 +43,8 @@ public class AbstractDocumentDetails {
                                    @JsonProperty("partyUploaded") UploadParty partyUploaded,
                                    @JsonProperty("dateApproved") String dateApproved,
                                    @JsonProperty("resizedDocumentLink") DocumentLink resizedDocumentLink,
-                                   @JsonProperty("avDocumentLink") DocumentLink avDocumentLink) {
+                                   @JsonProperty("avDocumentLink") DocumentLink avDocumentLink,
+                                   @JsonProperty("originalPartySender") String originalPartySender) {
 
         this.documentType = documentType;
         this.documentFileName = documentFileName;
@@ -57,6 +59,7 @@ public class AbstractDocumentDetails {
         this.dateApproved = dateApproved;
         this.resizedDocumentLink = resizedDocumentLink;
         this.avDocumentLink = avDocumentLink;
+        this.originalPartySender = originalPartySender;
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/AudioVideoEvidenceDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/AudioVideoEvidenceDetails.java
@@ -25,6 +25,7 @@ public class AudioVideoEvidenceDetails {
     private UploadParty partyUploaded;
     private ProcessedAction processedAction;
     private DocumentLink statementOfEvidencePdf;
+    private String originalPartySender;
 
     @JsonCreator
     public AudioVideoEvidenceDetails(@JsonProperty("documentType") String documentType,
@@ -39,7 +40,8 @@ public class AudioVideoEvidenceDetails {
                                          @JsonProperty("dateApproved") LocalDate dateApproved,
                                      @JsonProperty("partyUploaded") UploadParty partyUploaded,
                                      @JsonProperty("processedAction") ProcessedAction processedAction,
-                                     @JsonProperty("statementOfEvidencePdf") DocumentLink statementOfEvidencePdf) {
+                                     @JsonProperty("statementOfEvidencePdf") DocumentLink statementOfEvidencePdf,
+                                     @JsonProperty("originalPartySender") String originalPartySender) {
         this.documentType = documentType;
         this.documentLink = documentLink;
         this.rip1Document = rip1Document;
@@ -49,6 +51,7 @@ public class AudioVideoEvidenceDetails {
         this.partyUploaded = partyUploaded;
         this.processedAction = processedAction;
         this.statementOfEvidencePdf = statementOfEvidencePdf;
+        this.originalPartySender = originalPartySender;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DwpDocumentDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/DwpDocumentDetails.java
@@ -42,7 +42,7 @@ public class DwpDocumentDetails extends AbstractDocumentDetails {
                               @JsonProperty("dateApproved") String dateApproved,
                               @JsonProperty("avDocumentLink") DocumentLink avDocumentLink) {
 
-        super(documentType, documentFileName, documentDateAdded, documentLink, editedDocumentLink, documentComment, evidenceIssued, bundleAddition, documentTranslationStatus, partyUploaded, dateApproved, null, avDocumentLink);
+        super(documentType, documentFileName, documentDateAdded, documentLink, editedDocumentLink, documentComment, evidenceIssued, bundleAddition, documentTranslationStatus, partyUploaded, dateApproved, null, avDocumentLink, null);
 
         this.dwpEditedEvidenceReason = dwpEditedEvidenceReason;
         this.documentDateTimeAdded = documentDateTimeAdded;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsDocumentDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsDocumentDetails.java
@@ -36,7 +36,7 @@ public class SscsDocumentDetails extends AbstractDocumentDetails {
                                @JsonProperty("resizedDocumentLink") DocumentLink resizedDocumentLink,
                                @JsonProperty("avDocumentLink") DocumentLink avDocumentLink,
                                @JsonProperty("originalPartySender") String originalPartySender) {
-        super(documentType, documentFileName, documentDateAdded, documentLink, editedDocumentLink, documentComment, evidenceIssued, bundleAddition, documentTranslationStatus, partyUploaded, dateApproved, resizedDocumentLink, avDocumentLink);
+        super(documentType, documentFileName, documentDateAdded, documentLink, editedDocumentLink, documentComment, evidenceIssued, bundleAddition, documentTranslationStatus, partyUploaded, dateApproved, resizedDocumentLink, avDocumentLink, originalPartySender);
         this.documentEmailContent = documentEmailContent;
         this.controlNumber = controlNumber;
         this.editedDocumentLink = editedDocumentLink;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsWelshDocumentDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsWelshDocumentDetails.java
@@ -26,7 +26,7 @@ public class SscsWelshDocumentDetails extends AbstractDocumentDetails {
                                     @JsonProperty("documentLanguage") String documentLanguage,
                                     @JsonProperty("evidenceIssued") String evidenceIssued,
                                     @JsonProperty("bundleAddition") String bundleAddition) {
-        super(documentType, documentFileName, documentDateAdded, documentLink, null, documentComment, evidenceIssued, bundleAddition, null, null, null, null, null);
+        super(documentType, documentFileName, documentDateAdded, documentLink, null, documentComment, evidenceIssued, bundleAddition, null, null, null, null, null, null);
         this.originalDocumentFileName = originalDocumentFileName;
         this.documentComment = documentComment;
         this.documentLanguage = documentLanguage;


### PR DESCRIPTION
add original sender to audioVideoEvidence

Jira Ticket: [https://tools.hmcts.net/jira/browse/SSCS-9677](url)