### PR TITLE
feat/SSCS-10559: Adding overrideSchedulingListingFields

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/OverrideSchedulingListingFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/OverrideSchedulingListingFields.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.sscs.ccd.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OverrideSchedulingListingFields {
+
+    @JsonProperty("overrideDuration")
+    private int overrideDuration;
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/OverrideSchedulingListingFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/OverrideSchedulingListingFields.java
@@ -1,7 +1,19 @@
 package uk.gov.hmcts.reform.sscs.ccd.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OverrideSchedulingListingFields {
 
     @JsonProperty("overrideDuration")

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/OverrideSchedulingListingFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/OverrideSchedulingListingFields.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.sscs.ccd.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,6 +15,5 @@ import lombok.NoArgsConstructor;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class OverrideSchedulingListingFields {
 
-    @JsonProperty("overrideDuration")
     private int overrideDuration;
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SchedulingAndListingFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SchedulingAndListingFields.java
@@ -15,10 +15,8 @@ import lombok.NoArgsConstructor;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SchedulingAndListingFields {
     private HearingRoute hearingRoute;
-
     private HearingState hearingState;
-
     private Long activeHearingId;
-
     private Long activeHearingVersionNumber;
+    private OverrideSchedulingListingFields overrideSchedulingListingFields;
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-10559


### Change description ###
- Adding new class for overrideSchedulingListingFields - which contains the first field for override duration
- SchedulingAndListingFields class now contians OverrideSchedulingListingFields overrideSchedulingListingFields


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
