### PR TITLE
SSCS-12068 - Update for v2 e-links judicial user api call headers

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/JudicialUserPanel.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/JudicialUserPanel.java
@@ -1,21 +1,19 @@
 package uk.gov.hmcts.reform.sscs.ccd.domain;
 
+import static java.util.Objects.nonNull;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.sscs.model.client.JudicialUserBase;
-
-import static java.util.Objects.nonNull;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data

--- a/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
@@ -26,7 +26,7 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users/search",
-            headers = ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+            headers = {ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE}
     )
     List<JudicialUserSearch> searchUsersBySearchString(
             @RequestHeader(AUTHORIZATION) String authorisation,
@@ -37,7 +37,7 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users",
-            headers = ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+           headers = {ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE}
     )
     List<JudicialUser> getJudicialUsers(
             @RequestHeader(AUTHORIZATION) String authorisation,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
@@ -23,12 +23,11 @@ public interface JudicialRefDataApi {
     String SERVICE_AUTHORIZATION = "serviceAuthorization";
     String ACCEPT_HEADER_STRING = "application/vnd.jrd.api+json;Version=2.0";
 
-
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users/search",
-            consumes = APPLICATION_JSON_VALUE,
-            headers = ACCEPT + "=" + ACCEPT_HEADER_STRING
+            headers = {CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE,
+                    ACCEPT + "=" + ACCEPT_HEADER_STRING}
     )
     List<JudicialUserSearch> searchUsersBySearchString(
             @RequestHeader(AUTHORIZATION) String authorisation,
@@ -39,8 +38,8 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users",
-            consumes = APPLICATION_JSON_VALUE,
-            headers = ACCEPT + "=" + ACCEPT_HEADER_STRING
+            headers = {CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE,
+                    ACCEPT + "=" + ACCEPT_HEADER_STRING}
     )
     List<JudicialUser> getJudicialUsers(
             @RequestHeader(AUTHORIZATION) String authorisation,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
@@ -26,7 +26,7 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users/search",
-            headers = {ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE}
+            headers = ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
     )
     List<JudicialUserSearch> searchUsersBySearchString(
             @RequestHeader(AUTHORIZATION) String authorisation,
@@ -37,7 +37,7 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users",
-            headers = {ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE}
+            headers = ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
     )
     List<JudicialUser> getJudicialUsers(
             @RequestHeader(AUTHORIZATION) String authorisation,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
@@ -23,6 +23,7 @@ public interface JudicialRefDataApi {
     String SERVICE_AUTHORIZATION = "serviceAuthorization";
     String ACCEPT_HEADER_STRING = "application/vnd.jrd.api+json;Version=2.0";
 
+
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users/search",

--- a/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.sscs.client;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
@@ -22,11 +21,12 @@ import uk.gov.hmcts.reform.sscs.model.client.JudicialUserSearch;
 public interface JudicialRefDataApi {
 
     String SERVICE_AUTHORIZATION = "serviceAuthorization";
+    String acceptHeaderString = "application/vnd.jrd.api+json;Version=2.0";
 
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users/search",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+            headers = "{" + ACCEPT + "=" + acceptHeaderString + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
     )
     List<JudicialUserSearch> searchUsersBySearchString(
             @RequestHeader(AUTHORIZATION) String authorisation,
@@ -37,7 +37,7 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users",
-            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+            headers = "{" + ACCEPT + "=" + acceptHeaderString + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
     )
     List<JudicialUser> getJudicialUsers(
             @RequestHeader(AUTHORIZATION) String authorisation,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
@@ -26,7 +26,8 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users/search",
-            headers = "{" + ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
+            consumes = APPLICATION_JSON_VALUE,
+            headers = ACCEPT + "=" + ACCEPT_HEADER_STRING
     )
     List<JudicialUserSearch> searchUsersBySearchString(
             @RequestHeader(AUTHORIZATION) String authorisation,
@@ -37,7 +38,8 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users",
-           headers = "{" + ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
+            consumes = APPLICATION_JSON_VALUE,
+            headers = ACCEPT + "=" + ACCEPT_HEADER_STRING
     )
     List<JudicialUser> getJudicialUsers(
             @RequestHeader(AUTHORIZATION) String authorisation,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
@@ -21,12 +21,12 @@ import uk.gov.hmcts.reform.sscs.model.client.JudicialUserSearch;
 public interface JudicialRefDataApi {
 
     String SERVICE_AUTHORIZATION = "serviceAuthorization";
-    String acceptHeaderString = "application/vnd.jrd.api+json;Version=2.0";
+    String ACCEPT_HEADER_STRING = "application/vnd.jrd.api+json;Version=2.0";
 
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users/search",
-            headers = "{" + ACCEPT + "=" + acceptHeaderString + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
+            headers = "{" + ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
     )
     List<JudicialUserSearch> searchUsersBySearchString(
             @RequestHeader(AUTHORIZATION) String authorisation,
@@ -37,7 +37,7 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users",
-            headers = "{" + ACCEPT + "=" + acceptHeaderString + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
+            headers = "{" + ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
     )
     List<JudicialUser> getJudicialUsers(
             @RequestHeader(AUTHORIZATION) String authorisation,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
@@ -26,7 +26,7 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users/search",
-            headers = {ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE}
+            headers = "{" + ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
     )
     List<JudicialUserSearch> searchUsersBySearchString(
             @RequestHeader(AUTHORIZATION) String authorisation,
@@ -37,7 +37,7 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users",
-           headers = {ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE}
+           headers = "{" + ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
     )
     List<JudicialUser> getJudicialUsers(
             @RequestHeader(AUTHORIZATION) String authorisation,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/client/JudicialRefDataApi.java
@@ -26,7 +26,7 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users/search",
-            headers = "{" + ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
+            headers = {ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE}
     )
     List<JudicialUserSearch> searchUsersBySearchString(
             @RequestHeader(AUTHORIZATION) String authorisation,
@@ -37,7 +37,7 @@ public interface JudicialRefDataApi {
     @RequestMapping(
             method = RequestMethod.POST,
             value = "refdata/judicial/users",
-            headers = "{" + ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE + "}"
+            headers = {ACCEPT + "=" + ACCEPT_HEADER_STRING + "," + CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE}
     )
     List<JudicialUser> getJudicialUsers(
             @RequestHeader(AUTHORIZATION) String authorisation,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/model/client/JudicialMemberAppointments.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/model/client/JudicialMemberAppointments.java
@@ -39,7 +39,7 @@ public class JudicialMemberAppointments {
     @JsonProperty("service_code")
     private String serviceCode;
     @JsonProperty("start_date")
-    private String startDate;
+    private LocalDate startDate;
     @JsonProperty("end_date")
-    private String endDate;
+    private LocalDate endDate;
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/model/client/JudicialMemberAppointments.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/model/client/JudicialMemberAppointments.java
@@ -39,7 +39,7 @@ public class JudicialMemberAppointments {
     @JsonProperty("service_code")
     private String serviceCode;
     @JsonProperty("start_date")
-    private LocalDate startDate;
+    private String startDate;
     @JsonProperty("end_date")
-    private LocalDate endDate;
+    private String endDate;
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/model/client/JudicialMemberAuthorisations.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/model/client/JudicialMemberAuthorisations.java
@@ -2,7 +2,8 @@ package uk.gov.hmcts.reform.sscs.model.client;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.LocalDateTime;
+
+import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +25,7 @@ public class JudicialMemberAuthorisations {
     @JsonProperty("ticket_description")
     private String ticketDescription;
     @JsonProperty("start_date")
-    private String startDate;
+    private LocalDate startDate;
     @JsonProperty("end_date")
-    private String endDate;
+    private LocalDate endDate;
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/model/client/JudicialMemberAuthorisations.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/model/client/JudicialMemberAuthorisations.java
@@ -24,7 +24,7 @@ public class JudicialMemberAuthorisations {
     @JsonProperty("ticket_description")
     private String ticketDescription;
     @JsonProperty("start_date")
-    private LocalDateTime startDate;
+    private String startDate;
     @JsonProperty("end_date")
-    private LocalDateTime endDate;
+    private String endDate;
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/JudicialRefDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/JudicialRefDataServiceTest.java
@@ -12,10 +12,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.sscs.client.JudicialRefDataApi;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
-import uk.gov.hmcts.reform.sscs.model.client.JudicialRefDataSearchRequest;
 import uk.gov.hmcts.reform.sscs.model.client.JudicialRefDataUsersRequest;
 import uk.gov.hmcts.reform.sscs.model.client.JudicialUser;
-import uk.gov.hmcts.reform.sscs.model.client.JudicialUserSearch;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JudicialRefDataServiceTest {


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCS-12068

### Change description ###
Discovered during adjournment SIT testing, following error in demo;

This was found to be an issue with the headers being sent in requests from tribunals to the judicial api. These headers need to be updated after the V2 e-links updates made by the ref data team – see #jrd-e-links-api-v2 slack channel for more information.

To fix, per rf team, we need to update our header to send the following; accept:application/vnd.jrd.api+json;Version=2.0