### PR TITLE
SSCS-12215 - Add serializer for local date on final decision fields

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsFinalDecisionCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsFinalDecisionCaseData.java
@@ -1,10 +1,14 @@
 package uk.gov.hmcts.reform.sscs.ccd.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDate;
 import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -49,7 +53,11 @@ public class SscsFinalDecisionCaseData {
     private String finalDecisionJudge;
     private String finalDecisionHeldAt;
     private String finalDecisionIdamSurname;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate finalDecisionIssuedDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate finalDecisionGeneratedDate;
     private YesNo finalDecisionWasOriginalDecisionUploaded;
 


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCS-12215

### Change description ###

Context: 

I was just closing down some BF’s and I noticed two cases where the Judge has issued a corrected DN, they don’t appear to have been issued. They’re not appearing in the notifications tab, I checked some of the other cases that Judge’s had done corrections and they have been issued and are in the notifications tab.

The refs are 1680-7032-5218-4886 and 1669-9844-5600-3123. 