### PR TITLE
CVE minor or patch upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,5 +233,8 @@ dependencies {
 
     // CVE-2023-24998
     implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
+
+    // CVE-2024-25710
+    implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.26.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ dependencies {
 
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
 
-    implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: '1.14.2', {
+    implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: '1.14.3', {
         exclude group: 'commons-collections', module: 'commons-collections'
     }
 
@@ -240,6 +240,9 @@ dependencies {
     testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.28'
 
     // CVE-2023-24998
+    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
+
+    // CVE-2023-5072
     implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -137,14 +137,8 @@ dependencies {
     api group: 'com.google.guava', name: 'guava', version: '32.1.1-jre'
     api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
-    implementation group: 'org.springframework', name: 'spring-aop', version: '5.3.27'
-    implementation group: 'org.springframework', name: 'spring-beans', version: '5.3.27'
-    implementation group: 'org.springframework.boot', name: 'spring-boot', version: '2.7.12'
-    implementation group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '2.7.12'
-    implementation group: 'org.springframework', name: 'spring-context', version: '5.3.27'
-    implementation group: 'org.springframework', name: 'spring-expression', version: '5.3.27'
-    implementation group: 'org.springframework', name: 'spring-jcl', version: '5.3.27'
-    implementation group: 'org.springframework', name: 'spring-webmvc', version: '5.3.27'
+    implementation group: 'org.springframework.boot', name: 'spring-boot', version: '2.7.18'
+    implementation group: 'org.springframework', name: 'spring-webmvc', version: '5.3.32'
 
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.15.2'
@@ -178,7 +172,7 @@ dependencies {
         exclude group: 'org.springframework.cloud', module: 'spring-cloud-starter-openfeign'
     }
 
-    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: '2.7.12'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: '2.7.18'
 
     implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.1.2', {
         exclude group: 'org.springframework.cloud', module: 'spring-cloud-starter-openfeign'
@@ -188,7 +182,7 @@ dependencies {
         exclude group: 'org.springframework.cloud', module: 'spring-cloud-starter-openfeign'
     }
 
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.0.3', {
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.0.6', {
         exclude group: 'org.springframework.cloud', module: 'spring-cloud-starter'
         exclude group: 'org.springframework.cloud', module: 'spring-cloud-commons'
     }
@@ -215,9 +209,8 @@ dependencies {
 
     implementation group: 'org.yaml', name: 'snakeyaml', version: '2.0'
 
-    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: "2.7.12"
-    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: "2.7.12"
-    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.7.12'
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: "2.7.18"
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: "2.7.18"
     implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.10.0'
@@ -228,7 +221,6 @@ dependencies {
     testImplementation group: 'org.junit.platform', name: 'junit-platform-engine', version: '1.10.0'
 
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.4.0'
-    testImplementation group: 'org.springframework', name: 'spring-test', version: '5.3.27'
 
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
     testImplementation group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.1'
@@ -240,9 +232,6 @@ dependencies {
     testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.28'
 
     // CVE-2023-24998
-    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
-
-    // CVE-2023-5072
     implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -214,6 +214,8 @@ dependencies {
     annotationProcessor group: "org.projectlombok", name: "lombok", version: "1.18.28"
 
     implementation group: 'org.yaml', name: 'snakeyaml', version: '2.0'
+    // CVE-2023-24998
+    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: "2.7.12"
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: "2.7.12"

--- a/build.gradle
+++ b/build.gradle
@@ -152,8 +152,8 @@ dependencies {
 
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.31'
 
-    // CVE-2023-6378
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.14'
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.4.14'
 
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -152,8 +152,8 @@ dependencies {
 
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.31'
 
-    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.4.8'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.8'
+    // CVE-2023-6378
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.14'
 
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -214,8 +214,6 @@ dependencies {
     annotationProcessor group: "org.projectlombok", name: "lombok", version: "1.18.28"
 
     implementation group: 'org.yaml', name: 'snakeyaml', version: '2.0'
-    // CVE-2023-24998
-    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: "2.7.12"
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: "2.7.12"
@@ -240,5 +238,8 @@ dependencies {
     testRuntimeOnly group: 'org.hibernate.validator', name: 'hibernate-validator', version: '6.2.5.Final'
     testImplementation group: 'org.projectlombok', name: 'lombok', version: '1.18.28'
     testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.28'
+
+    // CVE-2023-24998
+    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 }
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,7 +3,6 @@
   <suppress until="2024-03-23">
     <cve>CVE-2023-2976</cve>
     <cve>CVE-2020-8908</cve>
-    <cve>CVE-2024-25710</cve>
     <cve>CVE-2023-35116</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,7 +3,6 @@
   <suppress until="2024-03-23">
     <cve>CVE-2023-2976</cve>
     <cve>CVE-2020-8908</cve>
-    <cve>CVE-2023-34053</cve>
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2024-25710</cve>
     <cve>CVE-2023-35116</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2024-03-23">
-    <cve>CVE-2023-24998</cve>
     <cve>CVE-2023-2976</cve>
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-34053</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,7 +3,6 @@
   <suppress until="2024-03-23">
     <cve>CVE-2023-2976</cve>
     <cve>CVE-2020-8908</cve>
-    <cve>CVE-2023-6378</cve>
     <cve>CVE-2024-25710</cve>
     <cve>CVE-2023-35116</cve>
   </suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,11 +2,11 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2024-03-23">
     <cve>CVE-2023-2976</cve>
+    <cve>CVE-2020-8908</cve>
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-34053</cve>
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2024-25710</cve>
-    <cve>CVE-2020-8908</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-34055</cve>
   </suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,7 +3,6 @@
   <suppress until="2024-03-23">
     <cve>CVE-2023-2976</cve>
     <cve>CVE-2020-8908</cve>
-    <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-34053</cve>
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2024-25710</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -6,6 +6,5 @@
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2024-25710</cve>
     <cve>CVE-2023-35116</cve>
-    <cve>CVE-2023-34055</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSCI-769

### Change description ###

CVE-2023-24998
There's no patch for the direct dependency, so **added a new dependency** for commons-fileupload@1.5

CVE-2023-2976, CVE-2020-8908
There is an existing dependency for com.google.guava:guava:32.1.1-jre and version 30.1.1-jre is only used by the checkstyle plugin. Plugin 'checkstyle' is a core Gradle plugin, which cannot be specified with a version number.  Such plugins are versioned as part of Gradle. Gradle 8.6 (latest version) uses com.puppycrawl.tools:checkstyle:9.3 (and com.google.guava:guava:31.0.1-jre), so upgrading gradle doesn't solve the CVE.

Could add a new dependency of com.puppycrawl.tools:checkstyle:8.45.1 to versrion 10.12.1 to fix CVE but that's a major, so **suppressing for now**.

CVE-2023-5072
**Patched** com.github.everit-org.json-schema:org.everit.json.schema:1.14.2 to version 1.14.3, it's a direct dependency and org.json:json:20230227 is a dependency of this package only

CVE-2023-34053
- **patched** org.springframework:spring-webmvc to version 5.3.32 because it's a dependency of org.springdoc:springdoc-openapi-ui:1.7.0 (latest version) and that uses spring-webmvc version 5.3.26 (has CVE), ideally it should be patched to 6.1.4
- removed some spring-boot packages because **bumping** spring-boot and spring-boot-starter-actuator to 2.7.18 and org.springframework.cloud:spring-cloud-starter-openfeign to 4.0.6 also upgrades the removed packages and fixes the CVE. The removed packages seem to be added as a CVE fix previously

CVE-2023-6378
**Patched** logback-classic and logback-core to version 1.4.14 as these are existing dependencies and patching other dependant packages doesn't fix the CVE

CVE-2023-35116
The recommended patch is 1.16.0 but the build fails with invalid definition exception so **suppressing** for now. There is also a new patch 2.15.4 which was released on 15 Feb 2024 and that doesn't break the build but it won't fix the CVE.

CVE-2023-34055
The fix for CVE-2023-34053 also fixes this CVE