### PR TITLE
SSCSCI-830 - Dwp Response Date Notifications

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/utility/dwpResponseUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/utility/dwpResponseUtil.java
@@ -5,7 +5,7 @@ public class dwpResponseUtil {
     public static final int MAX_DWP_RESPONSE_DAYS = 28;
     public static final int MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT = 42;
 
-    public int calculateMaxDwpResponseDays(String benefitCode) {
+    public static int calculateMaxDwpResponseDays(String benefitCode) {
         if (benefitCode == "childSupport" ) {
             return MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT;
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/utility/dwpResponseUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/utility/dwpResponseUtil.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.sscs.utility;
+
+public class dwpResponseUtil {
+
+    public static final int MAX_DWP_RESPONSE_DAYS = 28;
+    public static final int MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT = 42;
+
+    public int calculateMaxDwpResponseDays(String benefitCode) {
+        if (benefitCode == "childSupport" ) {
+            return MAX_DWP_RESPONSE_DAYS_CHILD_SUPPORT;
+        }
+        else {
+            return MAX_DWP_RESPONSE_DAYS;
+        }
+    };
+}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/SSCSCI-830


### Change description ###
Notifications messages should be sent after the event 'Sent to FTA'. Child Support cases should be calculated as 'Sent to FTA' event's date plus 42 days and all other case types as plus 28 days