### PR TITLE
Added recover method for update case v2 methods as the current retryable annotation for v2 doesn't have recover method

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/UpdateCcdCaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/UpdateCcdCaseService.java
@@ -36,7 +36,7 @@ public class UpdateCcdCaseService {
         this.ccdClient = ccdClient;
     }
 
-    @Retryable
+    @Retryable(recover = "recoverUpdateCaseV2Consumer")
     public SscsCaseDetails updateCaseV2(Long caseId, String eventType, String summary, String description, IdamTokens idamTokens, Consumer<SscsCaseDetails> mutator) {
         return updateCaseV2(caseId, eventType, idamTokens, caseDetails -> {
             mutator.accept(caseDetails);
@@ -44,7 +44,7 @@ public class UpdateCcdCaseService {
         });
     }
 
-    @Retryable
+    @Retryable(recover = "recoverTriggerCaseEventV2")
     public SscsCaseDetails triggerCaseEventV2(Long caseId, String eventType, String summary, String description, IdamTokens idamTokens) {
         return updateCaseV2(caseId, eventType, idamTokens, caseDetails -> new UpdateResult(summary, description));
     }
@@ -56,7 +56,7 @@ public class UpdateCcdCaseService {
      * Changes can be made to case data by the provided consumer which will always be provided
      * the current version of case data from CCD's start event.
      */
-    @Retryable
+    @Retryable(recover = "recoverUpdateCaseV2UpdateResult")
     public SscsCaseDetails updateCaseV2(Long caseId, String eventType, IdamTokens idamTokens, Function<SscsCaseDetails, UpdateResult> mutator) {
         log.info("UpdateCaseV2 for caseId {} and eventType {}", caseId, eventType);
         StartEventResponse startEventResponse = ccdClient.startEvent(idamTokens, caseId, eventType);
@@ -84,6 +84,7 @@ public class UpdateCcdCaseService {
      * Changes can be made to case data by the provided consumer which will always be provided
      * the current version of case data from CCD's start event.
      */
+    @Retryable(recover = "recoverUpdateCaseV2Conditional")
     public Optional<SscsCaseDetails> updateCaseV2Conditional(Long caseId, String eventType, IdamTokens idamTokens, Function<SscsCaseDetails, ConditionalUpdateResult> mutator) {
         log.info("UpdateCaseV2 for caseId {} and eventType {}", caseId, eventType);
         StartEventResponse startEventResponse = ccdClient.startEvent(idamTokens, caseId, eventType);
@@ -155,20 +156,26 @@ public class UpdateCcdCaseService {
      * Need to provide this so that recoverable/non-recoverable exception doesn't get wrapped in an IllegalArgumentException
      */
     @Recover
-    public int recover(RuntimeException exception, Long caseId, String eventType, String summary, String description, IdamTokens idamTokens, Consumer<SscsCaseDetails> mutator) {
+    public int recoverUpdateCaseV2Consumer(RuntimeException exception, Long caseId, String eventType, String summary, String description, IdamTokens idamTokens, Consumer<SscsCaseDetails> mutator) {
         log.error("In recover method(updateCaseV2 - Consumer) for caseId {} and eventType {} with exception {} ", caseId, eventType, exception.getMessage());
         throw exception;
     }
 
     @Recover
-    public int recover(RuntimeException exception, Long caseId, String eventType, String summary, String description, IdamTokens idamTokens) {
+    public int recoverTriggerCaseEventV2(RuntimeException exception, Long caseId, String eventType, String summary, String description, IdamTokens idamTokens) {
         log.error("In recover method(triggerCaseEventV2) for caseId {} and eventType {} with exception {} ", caseId, eventType, exception.getMessage());
         throw exception;
     }
 
     @Recover
-    public int recover(RuntimeException exception, Long caseId, String eventType, IdamTokens idamTokens, Function<SscsCaseDetails, ?> mutator) {
-        log.error("In recover method(updateCaseV2Conditional/updateCaseV2) for caseId {} and eventType {} with exception {} ", caseId, eventType, exception.getMessage());
+    public int recoverUpdateCaseV2UpdateResult(RuntimeException exception, Long caseId, String eventType, IdamTokens idamTokens, Function<SscsCaseDetails, UpdateResult> mutator) {
+        log.error("In recover method recoverUpdateCaseV2 for caseId {} and eventType {} with exception {} ", caseId, eventType, exception.getMessage());
+        throw exception;
+    }
+
+    @Recover
+    public int recoverUpdateCaseV2Conditional(RuntimeException exception, Long caseId, String eventType, IdamTokens idamTokens, Function<SscsCaseDetails, ConditionalUpdateResult> mutator) {
+        log.error("In recover method recoverUpdateCaseV2Conditional for caseId {} and eventType {} with exception {} ", caseId, eventType, exception.getMessage());
         throw exception;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/UpdateCcdCaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/UpdateCcdCaseService.java
@@ -84,7 +84,6 @@ public class UpdateCcdCaseService {
      * Changes can be made to case data by the provided consumer which will always be provided
      * the current version of case data from CCD's start event.
      */
-    @Retryable(maxAttempts = 2, backoff = @Backoff(maxDelay = 100L)) //100L = 100 ms
     public Optional<SscsCaseDetails> updateCaseV2Conditional(Long caseId, String eventType, IdamTokens idamTokens, Function<SscsCaseDetails, ConditionalUpdateResult> mutator) {
         log.info("UpdateCaseV2 for caseId {} and eventType {}", caseId, eventType);
         StartEventResponse startEventResponse = ccdClient.startEvent(idamTokens, caseId, eventType);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/UpdateCcdCaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/UpdateCcdCaseService.java
@@ -36,7 +36,7 @@ public class UpdateCcdCaseService {
         this.ccdClient = ccdClient;
     }
 
-    @Retryable(maxAttempts = 2, backoff = @Backoff(maxDelay = 100L)) //100L = 100 ms
+    @Retryable
     public SscsCaseDetails updateCaseV2(Long caseId, String eventType, String summary, String description, IdamTokens idamTokens, Consumer<SscsCaseDetails> mutator) {
         return updateCaseV2(caseId, eventType, idamTokens, caseDetails -> {
             mutator.accept(caseDetails);
@@ -44,7 +44,7 @@ public class UpdateCcdCaseService {
         });
     }
 
-    @Retryable(maxAttempts = 2, backoff = @Backoff(maxDelay = 100L)) //100L = 100 ms
+    @Retryable
     public SscsCaseDetails triggerCaseEventV2(Long caseId, String eventType, String summary, String description, IdamTokens idamTokens) {
         return updateCaseV2(caseId, eventType, idamTokens, caseDetails -> new UpdateResult(summary, description));
     }
@@ -56,7 +56,7 @@ public class UpdateCcdCaseService {
      * Changes can be made to case data by the provided consumer which will always be provided
      * the current version of case data from CCD's start event.
      */
-    @Retryable(maxAttempts = 2, backoff = @Backoff(maxDelay = 100L)) //100L = 100 ms
+    @Retryable
     public SscsCaseDetails updateCaseV2(Long caseId, String eventType, IdamTokens idamTokens, Function<SscsCaseDetails, UpdateResult> mutator) {
         log.info("UpdateCaseV2 for caseId {} and eventType {}", caseId, eventType);
         StartEventResponse startEventResponse = ccdClient.startEvent(idamTokens, caseId, eventType);
@@ -157,19 +157,19 @@ public class UpdateCcdCaseService {
      */
     @Recover
     public int recover(RuntimeException exception, Long caseId, String eventType, String summary, String description, IdamTokens idamTokens, Consumer<SscsCaseDetails> mutator) {
-        log.info("In recover method(updateCaseV2 - Consumer) for caseId {} and eventType {} with exception {} ", caseId, eventType, exception.getMessage());
+        log.error("In recover method(updateCaseV2 - Consumer) for caseId {} and eventType {} with exception {} ", caseId, eventType, exception.getMessage());
         throw exception;
     }
 
     @Recover
     public int recover(RuntimeException exception, Long caseId, String eventType, String summary, String description, IdamTokens idamTokens) {
-        log.info("In recover method(triggerCaseEventV2) for caseId {} and eventType {} with exception {} ", caseId, eventType, exception.getMessage());
+        log.error("In recover method(triggerCaseEventV2) for caseId {} and eventType {} with exception {} ", caseId, eventType, exception.getMessage());
         throw exception;
     }
 
     @Recover
     public int recover(RuntimeException exception, Long caseId, String eventType, IdamTokens idamTokens, Function<SscsCaseDetails, ?> mutator) {
-        log.info("In recover method(updateCaseV2Conditional/updateCaseV2) for caseId {} and eventType {} with exception {} ", caseId, eventType, exception.getMessage());
+        log.error("In recover method(updateCaseV2Conditional/updateCaseV2) for caseId {} and eventType {} with exception {} ", caseId, eventType, exception.getMessage());
         throw exception;
     }
 }


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSSI-225

### Change description ###

- When we introduced update Case V2 method with Consumer we didn’t add the recover method which is added for updateCase https://github.com/hmcts/sscs-common/blob/master/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/UpdateCcdCaseService.java#L137

- So what happens is for the existing update case it retries 3 times then goes to recover method which again calls update but this time without retry and hence if that fails it will throw original exception back

- Since we don’t have that recover method it get’s confused as it can’t find recover with consumer hence causing it to throw IllegalArgumentException

- This PR also overrides Retryable attempts to 2(default 3) and also backoff delay to 100ms

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
