### PR TITLE
Introduce handleCcdCallbackMapV2 which fetches latest data from DB and updates CCD instead of updating case data with stale copy

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/CcdCallbackMapService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/service/CcdCallbackMapService.java
@@ -13,14 +13,23 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 
+import java.util.Optional;
+
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CcdCallbackMapService {
     private final CcdService ccdService;
+    private final UpdateCcdCaseService updateCcdCaseService;
     private final IdamService idamService;
 
+    /**
+     * Updates CCD with stale case data hence use handleCcdCallbackMapV2 which retrieves latest data from DB
+     *
+     * @deprecated use {@link #handleCcdCallbackMapV2()} instead.
+     */
+    @Deprecated
     public SscsCaseData handleCcdCallbackMap(@Nullable CcdCallbackMap callbackMap, @Valid SscsCaseData caseData) {
         if (isNull(callbackMap)) {
             return caseData;
@@ -29,18 +38,15 @@ public class CcdCallbackMapService {
         Long caseId = Long.valueOf(caseData.getCcdCaseId());
 
         if (nonNull(callbackMap.getPostCallbackDwpState())) {
-            log.info("Setting DwpState to {} for case {}", callbackMap.getPostCallbackDwpState(), caseId);
-            caseData.setDwpState(callbackMap.getPostCallbackDwpState());
+            setDwpState(callbackMap, caseId, caseData);
         }
 
         if (nonNull(callbackMap.getPostCallbackInterlocState())) {
-            log.info("Setting InterlocReviewState to {} for case {}", callbackMap.getPostCallbackInterlocState(), caseId);
-            caseData.setInterlocReviewState(callbackMap.getPostCallbackInterlocState());
+            setInterlocReviewState(callbackMap, caseData, caseId);
         }
 
         if (nonNull(callbackMap.getPostCallbackInterlocReason())) {
-            log.info("Setting InterlocReferralReason to {} for case {}", callbackMap.getPostCallbackInterlocReason(), caseId);
-            caseData.setInterlocReferralReason(callbackMap.getPostCallbackInterlocReason());
+            setInterlocReferralReason(callbackMap, caseData, caseId);
         }
 
         if (nonNull(callbackMap.getCallbackEvent())) {
@@ -50,6 +56,55 @@ public class CcdCallbackMapService {
             return updatedCaseDetails.getData();
         }
         return caseData;
+    }
+
+    public Optional<SscsCaseData> handleCcdCallbackMapV2(@Nullable CcdCallbackMap callbackMap, long caseId) {
+
+        if (isNull(callbackMap)) {
+            return Optional.empty();
+        }
+
+        if (nonNull(callbackMap.getCallbackEvent())) {
+            log.info("Triggering update case v2 for event type {} and case {}", callbackMap.getCallbackEvent().getCcdType(), caseId);
+            SscsCaseDetails updatedCaseDetails = updateCcdCaseService.updateCaseV2(
+                    caseId,
+                    callbackMap.getCallbackEvent().getCcdType(),
+                    callbackMap.getCallbackSummary(),
+                    callbackMap.getCallbackDescription(),
+                    idamService.getIdamTokens(),
+                    sscsCaseData -> {
+                        if (nonNull(callbackMap.getPostCallbackDwpState())) {
+                            setDwpState(callbackMap, caseId, sscsCaseData);
+                        }
+
+                        if (nonNull(callbackMap.getPostCallbackInterlocState())) {
+                            setInterlocReviewState(callbackMap, sscsCaseData, caseId);
+                        }
+
+                        if (nonNull(callbackMap.getPostCallbackInterlocReason())) {
+                            setInterlocReferralReason(callbackMap, sscsCaseData, caseId);
+                        }
+                    }
+            );
+
+            return Optional.of(updatedCaseDetails.getData());
+        }
+        return Optional.empty();
+    }
+
+    private static void setDwpState(CcdCallbackMap callbackMap, long caseId, SscsCaseData sscsCaseData) {
+        log.info("Setting DwpState to {} for case {}", callbackMap.getPostCallbackDwpState(), caseId);
+        sscsCaseData.setDwpState(callbackMap.getPostCallbackDwpState());
+    }
+
+    private static void setInterlocReferralReason(CcdCallbackMap callbackMap, SscsCaseData caseData, Long caseId) {
+        log.info("Setting InterlocReferralReason to {} for case {}", callbackMap.getPostCallbackInterlocReason(), caseId);
+        caseData.setInterlocReferralReason(callbackMap.getPostCallbackInterlocReason());
+    }
+
+    private static void setInterlocReviewState(CcdCallbackMap callbackMap, SscsCaseData caseData, Long caseId) {
+        log.info("Setting InterlocReviewState to {} for case {}", callbackMap.getPostCallbackInterlocState(), caseId);
+        caseData.setInterlocReviewState(callbackMap.getPostCallbackInterlocState());
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/service/CcdCallbackMapServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/service/CcdCallbackMapServiceTest.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.sscs.ccd.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -8,10 +10,13 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.DwpState.DIRECTION_ACTION_REQUIRED;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.READY_TO_LIST;
 
+import org.checkerframework.checker.units.qual.C;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -22,13 +27,20 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 
+import java.util.Optional;
+import java.util.function.Consumer;
+
 @ExtendWith(MockitoExtension.class)
 class CcdCallbackMapServiceTest {
     private static final long CASE_ID = 1234;
     @Mock
     private CcdService ccdService;
     @Mock
+    private UpdateCcdCaseService updateCcdCaseService;
+    @Mock
     private IdamService idamService;
+    @Captor
+    private ArgumentCaptor<Consumer<SscsCaseData>>  sscsCaseDataArgumentCaptor;
 
     @InjectMocks
     private CcdCallbackMapService ccdCallbackMapService;
@@ -57,6 +69,17 @@ class CcdCallbackMapServiceTest {
         verifyNoInteractions(ccdService, idamService);
     }
 
+    @DisplayName("When callbackMap is null handleCcdCallbackMapV2 returns empty optional and doesn't call "
+            + "ccdService")
+    @Test
+    void handleCcdCallbackNullCallbackMapV2() {
+
+        Optional<SscsCaseData> result = ccdCallbackMapService.handleCcdCallbackMapV2(null, CASE_ID);
+
+        assertThat(result).isEmpty();
+        verifyNoInteractions(ccdService, idamService);
+    }
+
     @DisplayName("When PostCallbackDwpState is null handleCcdCallbackMap leaves the Dwp State unmodified")
     @Test
     void handleCcdCallbackNullPostCallbackDwpState() {
@@ -78,6 +101,30 @@ class CcdCallbackMapServiceTest {
         assertThat(result.getDwpState()).isEqualTo(expected);
     }
 
+    @DisplayName("When PostCallbackDwpState is not null handleCcdCallbackMapV2 correctly sets the Dwp State")
+    @Test
+    void handleCcdCallbackV2PostCallbackDwpState() {
+        given(callbackMap.getPostCallbackDwpState()).willReturn(DIRECTION_ACTION_REQUIRED);
+        given(callbackMap.getCallbackEvent()).willReturn(READY_TO_LIST);
+        given(callbackMap.getCallbackSummary()).willReturn("summary");
+        given(callbackMap.getCallbackDescription()).willReturn("description");
+        given(idamService.getIdamTokens()).willReturn(idamTokens);
+        given(updateCcdCaseService
+                .updateCaseV2(eq(CASE_ID), eq(READY_TO_LIST.getCcdType()), eq("summary"), eq("description"), eq(idamTokens), any(Consumer.class)))
+                .willReturn(SscsCaseDetails.builder().id(CASE_ID).data(caseData).build());
+
+        Optional<SscsCaseData> result = ccdCallbackMapService.handleCcdCallbackMapV2(callbackMap, CASE_ID);
+
+        assertThat(result).isNotEmpty();
+
+        verify(updateCcdCaseService, times(1))
+                .updateCaseV2(eq(CASE_ID), eq(READY_TO_LIST.getCcdType()), eq("summary"), eq("description"), eq(idamTokens), sscsCaseDataArgumentCaptor.capture());
+
+        sscsCaseDataArgumentCaptor.getValue().accept(caseData);
+
+        assertThat(result.get().getDwpState()).isEqualTo(DIRECTION_ACTION_REQUIRED);
+    }
+
     @DisplayName("When CallbackEvent is null handleCcdCallbackMap doesn't call ccdService")
     @Test
     void handleCcdCallbackNullCallbackEvent() {
@@ -88,7 +135,17 @@ class CcdCallbackMapServiceTest {
         verifyNoInteractions(ccdService, idamService);
     }
 
-    @DisplayName("When CallbackEvent is null handleCcdCallbackMap doesn't call ccdService")
+    @DisplayName("When CallbackEvent is null handleCcdCallbackMapV2 doesn't call ccdService")
+    @Test
+    void handleCcdCallbackV2NullCallbackEvent() {
+        given(callbackMap.getCallbackEvent()).willReturn(null);
+
+        ccdCallbackMapService.handleCcdCallbackMapV2(callbackMap, CASE_ID);
+
+        verifyNoInteractions(ccdService, idamService);
+    }
+
+    @DisplayName("When CallbackEvent is not null handleCcdCallbackMap will call ccdService")
     @Test
     void handleCcdCallbackCallbackEvent() {
         given(callbackMap.getCallbackEvent()).willReturn(READY_TO_LIST);
@@ -111,5 +168,32 @@ class CcdCallbackMapServiceTest {
         verify(idamService, times(1)).getIdamTokens();
 
         assertThat(result).isEqualTo(expected);
+    }
+
+    @DisplayName("When CallbackEvent is not null handleCcdCallbackMapV2 will call ccdService")
+    @Test
+    void handleCcdCallbackEventV2() {
+        given(callbackMap.getCallbackEvent()).willReturn(READY_TO_LIST);
+        given(callbackMap.getCallbackSummary()).willReturn("summary");
+        given(callbackMap.getCallbackDescription()).willReturn("description");
+
+        given(idamService.getIdamTokens()).willReturn(idamTokens);
+
+        SscsCaseData expected = SscsCaseData.builder().ccdCaseId(String.valueOf(CASE_ID)).build();
+
+        given(updateCcdCaseService
+                .updateCaseV2(eq(CASE_ID), eq(READY_TO_LIST.getCcdType()), eq("summary"), eq("description"), eq(idamTokens), any(Consumer.class)))
+                .willReturn(SscsCaseDetails.builder().id(CASE_ID).data(caseData).build());
+
+        Optional<SscsCaseData> result = ccdCallbackMapService.handleCcdCallbackMapV2(callbackMap, CASE_ID);
+
+        assertThat(result).isNotEmpty();
+
+        verify(updateCcdCaseService, times(1))
+                .updateCaseV2(eq(CASE_ID), eq(READY_TO_LIST.getCcdType()), eq("summary"), eq("description"), eq(idamTokens), sscsCaseDataArgumentCaptor.capture());
+        verify(idamService, times(1)).getIdamTokens();
+
+        sscsCaseDataArgumentCaptor.getValue().accept(caseData);
+        assertThat(caseData).usingRecursiveComparison().ignoringFields("jointParty.id").isEqualTo(expected);
     }
 }


### PR DESCRIPTION

### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSSI-332

### Change description ###

- Deprecate existing `handleCcdCallbackMap` which uses stale copy of data to update case data in DB.
- Introduce `handleCcdCallbackMapV2` and migrate event handlers to this new method which works on latest data from DB.
