### PR TITLE
Bump dependency check plugin to 10.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'checkstyle'
     id 'pmd'
     id 'jacoco'
-    id 'org.owasp.dependencycheck' version '10.0.1'
+    id 'org.owasp.dependencycheck' version '10.0.2'
 }
 
 def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "DEV-SNAPSHOT"


### PR DESCRIPTION
### Change description ###

There is a mandatory dependency check plugin update: https://github.com/jeremylong/DependencyCheck?tab=readme-ov-file#mandatory-upgrade-notice that will allow the NVD to block calls from the older client

Bumped dependency check to 10.0.2