### PR TITLE
SSCSCI-1945: consolidate panelComposition calculation logic and reset when stale

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventType.java
@@ -39,6 +39,7 @@ public enum EventType {
     ADMIN_UPDATE_EVENT("adminUpdateEvent", 0, false),
     AMEND_DUE_DATE("amendDueDate", 0, false),
     AMEND_ELEMENTS_ISSUES("amendElementsIssues", 0, false),
+    AMEND_SPECIALISM("panelDoctorSpecialismAmend", 0, false),
     APPEAL_RECEIVED("appealReceived", "appealReceived", 1, true),
     APPEAL_TO_PROCEED("appealToProceed", 0, false),
     ASSIGN_TO_JUDGE("assignToJudge", 0, false),

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberComposition.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberComposition.java
@@ -23,6 +23,8 @@ import org.springframework.util.ObjectUtils;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PanelMemberComposition {
 
+    protected static final String FQPM_REF = PanelMemberType.TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef();
+
     private String districtTribunalJudge;
     private String panelCompositionJudge;
     private String panelCompositionMemberMedical1;
@@ -82,5 +84,38 @@ public class PanelMemberComposition {
                 isNull(panelCompositionMemberMedical1) &&
                 isNull(panelCompositionMemberMedical2) &&
                 ObjectUtils.isEmpty(panelCompositionDisabilityAndFqMember);
+    }
+
+    @JsonIgnore
+    public boolean hasFqpm() {
+        return nonNull(panelCompositionDisabilityAndFqMember)
+            && panelCompositionDisabilityAndFqMember.contains(FQPM_REF);
+    }
+
+    @JsonIgnore
+    public void addFqpm() {
+        if (isNull(panelCompositionDisabilityAndFqMember)) {
+            panelCompositionDisabilityAndFqMember = new ArrayList<>(List.of(FQPM_REF));
+        } else if (!panelCompositionDisabilityAndFqMember.contains(FQPM_REF)) {
+            panelCompositionDisabilityAndFqMember.add(FQPM_REF);
+        }
+    }
+
+    @JsonIgnore
+    public void removeFqpm() {
+        if (nonNull(panelCompositionDisabilityAndFqMember)) {
+            panelCompositionDisabilityAndFqMember.remove(FQPM_REF);
+        }
+    }
+
+    @JsonIgnore
+    public boolean hasMedicalMember() {
+        return nonNull(panelCompositionMemberMedical1) || nonNull(panelCompositionMemberMedical2);
+    }
+
+    @JsonIgnore
+    public void clearMedicalMembers() {
+        panelCompositionMemberMedical1 = null;
+        panelCompositionMemberMedical2 = null;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberComposition.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberComposition.java
@@ -78,6 +78,7 @@ public class PanelMemberComposition {
     @JsonIgnore
     public boolean isEmpty() {
         return isNull(panelCompositionJudge) &&
+                isNull(districtTribunalJudge) &&
                 isNull(panelCompositionMemberMedical1) &&
                 isNull(panelCompositionMemberMedical2) &&
                 ObjectUtils.isEmpty(panelCompositionDisabilityAndFqMember);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberComposition.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberComposition.java
@@ -2,6 +2,9 @@ package uk.gov.hmcts.reform.sscs.ccd.domain;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import static org.apache.commons.collections4.CollectionUtils.addIgnoreNull;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.TRIBUNAL_MEMBER_MEDICAL;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.getPanelMemberType;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -19,12 +22,58 @@ import org.springframework.util.ObjectUtils;
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PanelMemberComposition {
-    protected static final String FQPM_REF = PanelMemberType.TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef();
 
+    private String districtTribunalJudge;
     private String panelCompositionJudge;
     private String panelCompositionMemberMedical1;
     private String panelCompositionMemberMedical2;
     private List<String> panelCompositionDisabilityAndFqMember;
+
+
+    public PanelMemberComposition(List<String> johTiers) {
+        this.panelCompositionDisabilityAndFqMember = new ArrayList<>();
+        for (String johTier : johTiers) {
+            switch (getPanelMemberType(johTier)) {
+                case TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED:
+                case TRIBUNAL_MEMBER_DISABILITY:
+                    this.panelCompositionDisabilityAndFqMember.add(johTier);
+                    break;
+                case TRIBUNAL_MEMBER_MEDICAL:
+                    if(nonNull(this.panelCompositionMemberMedical1)) {
+                        this.panelCompositionMemberMedical2 = johTier;
+                    } else {
+                        this.panelCompositionMemberMedical1 = johTier;
+                    }
+                break;
+                case REGIONAL_MEDICAL_MEMBER:
+                    if (nonNull(this.panelCompositionMemberMedical1)) {
+                        this.panelCompositionMemberMedical2 = TRIBUNAL_MEMBER_MEDICAL.toRef();
+                    }
+                    this.panelCompositionMemberMedical1 = johTier;
+                    break;
+                case TRIBUNAL_JUDGE:
+                case REGIONAL_TRIBUNAL_JUDGE:
+                    this.panelCompositionJudge = johTier;
+                    break;
+                case DISTRICT_TRIBUNAL_JUDGE:
+                    this.districtTribunalJudge = johTier;
+                    break;
+            }
+        }
+    }
+
+    @JsonIgnore
+    public List<String> getJohTiers() {
+        List<String> roleTypes = new ArrayList<>();
+        addIgnoreNull(roleTypes, this.districtTribunalJudge);
+        addIgnoreNull(roleTypes, this.panelCompositionJudge);
+        addIgnoreNull(roleTypes, this.panelCompositionMemberMedical1);
+        addIgnoreNull(roleTypes, this.panelCompositionMemberMedical2);
+        if(nonNull(this.panelCompositionDisabilityAndFqMember)) {
+            roleTypes.addAll(this.panelCompositionDisabilityAndFqMember);
+        }
+        return roleTypes;
+    }
 
     @JsonIgnore
     public boolean isEmpty() {
@@ -32,38 +81,5 @@ public class PanelMemberComposition {
                 isNull(panelCompositionMemberMedical1) &&
                 isNull(panelCompositionMemberMedical2) &&
                 ObjectUtils.isEmpty(panelCompositionDisabilityAndFqMember);
-    }
-
-    @JsonIgnore
-    public boolean hasFqpm() {
-        return nonNull(panelCompositionDisabilityAndFqMember)
-            && panelCompositionDisabilityAndFqMember.contains(FQPM_REF);
-    }
-
-    @JsonIgnore
-    public void addFqpm() {
-        if (isNull(panelCompositionDisabilityAndFqMember)) {
-            panelCompositionDisabilityAndFqMember = new ArrayList<>(List.of(FQPM_REF));
-        } else if (!panelCompositionDisabilityAndFqMember.contains(FQPM_REF)) {
-            panelCompositionDisabilityAndFqMember.add(FQPM_REF);
-        }
-    }
-
-    @JsonIgnore
-    public void removeFqpm() {
-        if (nonNull(panelCompositionDisabilityAndFqMember)) {
-            panelCompositionDisabilityAndFqMember.remove(FQPM_REF);
-        }
-    }
-
-    @JsonIgnore
-    public boolean hasMedicalMember() {
-        return nonNull(panelCompositionMemberMedical1) || nonNull(panelCompositionMemberMedical2);
-    }
-
-    @JsonIgnore
-    public void clearMedicalMembers() {
-        panelCompositionMemberMedical1 = null;
-        panelCompositionMemberMedical2 = null;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/model/DefaultPanelComposition.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/model/DefaultPanelComposition.java
@@ -35,7 +35,7 @@ public class DefaultPanelComposition {
         this.johTiers = new ArrayList<>();
     }
 
-    private String getSpecialismCount(SscsCaseData caseData) {
+    public static String getSpecialismCount(SscsCaseData caseData) {
         return caseData.getSscsIndustrialInjuriesData().getPanelDoctorSpecialism() != null
                 ? caseData.getSscsIndustrialInjuriesData().getSecondPanelDoctorSpecialism() != null
                 ? "2" : "1" : null;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/model/DefaultPanelComposition.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/model/DefaultPanelComposition.java
@@ -1,18 +1,21 @@
 package uk.gov.hmcts.reform.sscs.reference.data.model;
 
+import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.isYes;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@NoArgsConstructor
 @Data
 @Slf4j
 public class DefaultPanelComposition {
+
     private String benefitIssueCode;
     private String category;
     private String specialismCount;
@@ -20,11 +23,22 @@ public class DefaultPanelComposition {
     private String medicalMember;
     private List<String> johTiers;
 
-    public DefaultPanelComposition(String benefitIssueCode, String specialismCount, String fqpm, String medicalMember) {
-        this.benefitIssueCode = benefitIssueCode;
-        this.specialismCount = specialismCount;
-        this.fqpm = fqpm;
-        this.medicalMember = medicalMember;
+    public DefaultPanelComposition(SscsCaseData caseData) {
+        this.benefitIssueCode = caseData.getBenefitCode() + caseData.getIssueCode();
+        this.specialismCount = getSpecialismCount(caseData);
+        this.fqpm = isYes(caseData.getIsFqpmRequired()) ? caseData.getIsFqpmRequired().getValue().toLowerCase() : null;;
+        this.medicalMember = isYes(caseData.getIsMedicalMemberRequired())
+                ? caseData.getIsMedicalMemberRequired().getValue().toLowerCase() : null;
+    }
+
+    public DefaultPanelComposition() {
+        this.johTiers = new ArrayList<>();
+    }
+
+    private String getSpecialismCount(SscsCaseData caseData) {
+        return caseData.getSscsIndustrialInjuriesData().getPanelDoctorSpecialism() != null
+                ? caseData.getSscsIndustrialInjuriesData().getSecondPanelDoctorSpecialism() != null
+                ? "2" : "1" : null;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/model/DefaultPanelComposition.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/model/DefaultPanelComposition.java
@@ -1,13 +1,19 @@
 package uk.gov.hmcts.reform.sscs.reference.data.model;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.isYes;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Issue;
 import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 
@@ -23,12 +29,13 @@ public class DefaultPanelComposition {
     private String medicalMember;
     private List<String> johTiers;
 
-    public DefaultPanelComposition(SscsCaseData caseData) {
-        this.benefitIssueCode = caseData.getBenefitCode() + caseData.getIssueCode();
+    public DefaultPanelComposition(String issueCode, SscsCaseData caseData) {
+        this.benefitIssueCode = caseData.getBenefitCode() + issueCode;
         this.specialismCount = getSpecialismCount(caseData);
         this.fqpm = isYes(caseData.getIsFqpmRequired()) ? caseData.getIsFqpmRequired().getValue().toLowerCase() : null;;
         this.medicalMember = isYes(caseData.getIsMedicalMemberRequired())
                 ? caseData.getIsMedicalMemberRequired().getValue().toLowerCase() : null;
+        this.johTiers = new ArrayList<>();
     }
 
     public DefaultPanelComposition() {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionService.java
@@ -33,15 +33,14 @@ public class PanelCompositionService {
         if (nonNull(caseData.getPanelMemberComposition()) && !caseData.getPanelMemberComposition().isEmpty()) {
             return caseData.getPanelMemberComposition().getJohTiers();
         } else {
-            return getDefaultJohTiers(caseData);
+            return getDefaultPanelComposition(caseData).getJohTiers();
         }
     }
 
-    public List<String> getDefaultJohTiers(SscsCaseData caseData) {
+    public DefaultPanelComposition getDefaultPanelComposition(SscsCaseData caseData) {
         return defaultPanelCompositions.stream()
                 .filter(new DefaultPanelComposition(caseData)::equals)
-                .findFirst().orElse(new DefaultPanelComposition())
-                .getJohTiers();
+                .findFirst().orElse(new DefaultPanelComposition());
     }
 
     public PanelMemberComposition resetPanelCompositionIfStale(SscsCaseData caseData, SscsCaseData caseDataBefore) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionService.java
@@ -64,13 +64,11 @@ public class PanelCompositionService {
         }
         Set<String> allElementsJohTiers = new HashSet<>();
         caseData.getIssueCodesForAllElementsDisputed().forEach(issueCode -> {
-            DefaultPanelComposition issueCodePanelComposition =  findDefaultPanelCompForIssueCode(issueCode, caseData);
-            if (nonNull(issueCodePanelComposition)) {
-                allElementsJohTiers.addAll(issueCodePanelComposition.getJohTiers());
-                if (Issue.SG.toString().equals(issueCode) || Issue.WC.toString().equals(issueCode)
-                        || isNull(defaultPanelComposition.getCategory())) {
-                    defaultPanelComposition.setCategory(issueCodePanelComposition.getCategory());
-                }
+            DefaultPanelComposition ucElementPanelComposition =  findDefaultPanelCompForIssueCode(issueCode, caseData);
+            allElementsJohTiers.addAll(ucElementPanelComposition.getJohTiers());
+            if (Issue.SG.toString().equals(issueCode) || Issue.WC.toString().equals(issueCode)
+                    || isNull(defaultPanelComposition.getCategory())) {
+                defaultPanelComposition.setCategory(ucElementPanelComposition.getCategory());
             }
         });
         defaultPanelComposition.setJohTiers(new ArrayList<>(allElementsJohTiers));
@@ -84,10 +82,11 @@ public class PanelCompositionService {
     }
 
     public PanelMemberComposition resetPanelCompositionIfStale(SscsCaseData caseData, SscsCaseData caseDataBefore) {
-        boolean hasIssueCodeChanged = !caseData.getIssueCode().equals(caseDataBefore.getIssueCode());
+        boolean hasBenefitCodeChanged = !Objects.equals(caseData.getBenefitCode(), caseDataBefore.getBenefitCode());
+        boolean hasIssueCodeChanged = !Objects.equals(caseData.getIssueCode(), caseDataBefore.getIssueCode());
         boolean hasSpecialismCountChanged =
                 !Objects.equals(getSpecialismCount(caseData), getSpecialismCount(caseDataBefore));
-        return hasIssueCodeChanged || hasSpecialismCountChanged
+        return hasBenefitCodeChanged || hasIssueCodeChanged || hasSpecialismCountChanged
                 ? new PanelMemberComposition() : caseData.getPanelMemberComposition();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionService.java
@@ -1,32 +1,15 @@
 package uk.gov.hmcts.reform.sscs.reference.data.service;
 
-import static java.util.Collections.frequency;
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import static org.apache.commons.collections4.CollectionUtils.addIgnoreNull;
-import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.DISTRICT_TRIBUNAL_JUDGE;
-import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.REGIONAL_MEDICAL_MEMBER;
-import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.TRIBUNAL_MEMBER_MEDICAL;
-import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.getPanelMemberType;
-import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.isYes;
 import static uk.gov.hmcts.reform.sscs.reference.data.helper.ReferenceDataHelper.getReferenceData;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Issue;
-import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberComposition;
-import uk.gov.hmcts.reform.sscs.ccd.domain.ReserveTo;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.ccd.domain.YesNo;
 import uk.gov.hmcts.reform.sscs.reference.data.model.DefaultPanelComposition;
 
 @Getter
@@ -44,149 +27,21 @@ public class PanelCompositionService {
     }
 
     public List<String> getRoleTypes(SscsCaseData caseData) {
-        if (nonNull(caseData.getPanelMemberComposition()) &&
-                (!caseData.getPanelMemberComposition().isEmpty() || isDtjSelected(caseData))) {
-            updatePanelCompositionFromSpecialismCount(caseData);
-            List<String> johTiersFromExistingPanelComposition = getJohTiersFromPanelComposition(caseData.getPanelMemberComposition(), caseData);
-            log.info("Existing Panel Composition for case id: {} has joh tiers: {} ",
-                    caseData.getCcdCaseId(), johTiersFromExistingPanelComposition);
-            return johTiersFromExistingPanelComposition;
+        if (nonNull(caseData.getPanelMemberComposition()) && !caseData.getPanelMemberComposition().isEmpty()) {
+            return caseData.getPanelMemberComposition().getJohTiers();
         } else {
-            DefaultPanelComposition defaultPanelComposition = getDefaultPanelComposition(caseData);
-            log.info("Default Panel Composition for case id {} has been calculated as : {}",
-                    caseData.getCcdCaseId(), defaultPanelComposition);
-            return nonNull(defaultPanelComposition) && isNotEmpty(defaultPanelComposition.getJohTiers())
-                    ? defaultPanelComposition.getJohTiers() : new ArrayList<>();
-        }
-    }
-  
-    public PanelMemberComposition createPanelComposition(SscsCaseData caseData) {
-        DefaultPanelComposition defaultPanelComposition = getDefaultPanelComposition(caseData);
-        List<String> defaultJohTiers =
-                nonNull(defaultPanelComposition) && isNotEmpty(defaultPanelComposition.getJohTiers())
-                        ? defaultPanelComposition.getJohTiers() : new ArrayList<>();
-        return createPanelCompositionFromJohTiers(defaultJohTiers);
-    }
-
-    public DefaultPanelComposition getDefaultPanelComposition(SscsCaseData caseData) {
-        String benefitIssueCode = caseData.getBenefitCode() + caseData.getIssueCode();
-        String specialismCount = getSpecialismCount(caseData);
-        String isFqpm =
-                isYes(caseData.getIsFqpmRequired()) ? caseData.getIsFqpmRequired().getValue().toLowerCase() : null;
-        String isMedicalMember = isYes(caseData.getIsMedicalMemberRequired())
-                ? caseData.getIsMedicalMemberRequired().getValue().toLowerCase() : null;
-        if (List.of(Issue.UM.toString(), Issue.US.toString()).contains(caseData.getIssueCode())) {
-            log.info("Using Universal Credit default panel composition calculator for case {}", caseData.getCcdCaseId());
-            return getUniversalCreditDefaultPanelComposition(caseData, benefitIssueCode, specialismCount, isFqpm, isMedicalMember);
-        } else {
-            log.info("Using default panel composition calculator for case {}", caseData.getCcdCaseId());
-            return defaultPanelCompositions.stream()
-                    .filter(new DefaultPanelComposition(benefitIssueCode, specialismCount, isFqpm, isMedicalMember)::equals)
-                    .findFirst().orElse(null);
+            return getDefaultJohTiers(caseData);
         }
     }
 
-    private static List<String> getJohTiersFromPanelComposition(PanelMemberComposition panelMemberComposition, SscsCaseData caseData) {
-        List<String> roleTypes = new ArrayList<>();
-        ReserveTo reserveTo = caseData.getSchedulingAndListingFields().getReserveTo();
-        if (reserveTo != null && YesNo.YES.equals(reserveTo.getReservedDistrictTribunalJudge())) {
-            roleTypes.add(DISTRICT_TRIBUNAL_JUDGE.toRef());
-        } else {
-            addIgnoreNull(roleTypes, panelMemberComposition.getPanelCompositionJudge());
-        }
-        addIgnoreNull(roleTypes, panelMemberComposition.getPanelCompositionMemberMedical1());
-        addIgnoreNull(roleTypes, panelMemberComposition.getPanelCompositionMemberMedical2());
-
-        if(nonNull(panelMemberComposition.getPanelCompositionDisabilityAndFqMember())) {
-            roleTypes.addAll(panelMemberComposition.getPanelCompositionDisabilityAndFqMember());
-        }
-        return roleTypes;
-    }
-
-    public PanelMemberComposition createPanelCompositionFromJohTiers(List<String> johTiers) {
-        PanelMemberComposition panelMemberComposition = new PanelMemberComposition();
-        panelMemberComposition.setPanelCompositionDisabilityAndFqMember(new ArrayList<>());
-        for (String johTier : johTiers) {
-            switch (getPanelMemberType(johTier)) {
-                case TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED:
-                case TRIBUNAL_MEMBER_DISABILITY:
-                    panelMemberComposition.getPanelCompositionDisabilityAndFqMember().add(johTier);
-                    break;
-                case TRIBUNAL_MEMBER_MEDICAL:
-                    if((frequency(johTiers, TRIBUNAL_MEMBER_MEDICAL.toRef()) > 1
-                            && nonNull(panelMemberComposition.getPanelCompositionMemberMedical1()))
-                            || johTiers.contains(REGIONAL_MEDICAL_MEMBER.toRef())) {
-                        panelMemberComposition.setPanelCompositionMemberMedical2(TRIBUNAL_MEMBER_MEDICAL.toRef());
-                    } else {
-                        panelMemberComposition.setPanelCompositionMemberMedical1(TRIBUNAL_MEMBER_MEDICAL.toRef());
-                    }
-                    break;
-                case REGIONAL_MEDICAL_MEMBER:
-                    panelMemberComposition.setPanelCompositionMemberMedical1(johTier);
-                    break;
-                case TRIBUNAL_JUDGE:
-                case REGIONAL_TRIBUNAL_JUDGE:
-                case DISTRICT_TRIBUNAL_JUDGE:
-                    panelMemberComposition.setPanelCompositionJudge(johTier);
-                    break;
-            }
-        }
-        return panelMemberComposition;
-    }
-
-    private boolean isDtjSelected(SscsCaseData caseData) {
-        ReserveTo reserveTo = caseData.getSchedulingAndListingFields().getReserveTo();
-        return nonNull(reserveTo) && isYes(reserveTo.getReservedDistrictTribunalJudge());
-    }
-
-    private DefaultPanelComposition getUniversalCreditDefaultPanelComposition(SscsCaseData caseData, String benefitIssueCode, String specialismCount, String isFqpm, String isMedicalMember) {
-        List<String> issueCodesForAllElementsDisputed = caseData.getIssueCodesForAllElementsDisputed();
-        DefaultPanelComposition defaultPanelComposition = new DefaultPanelComposition(benefitIssueCode, specialismCount, isFqpm, isMedicalMember);
-        Set<String> johTiersSet = new HashSet<>();
-        Set<String> sessionCategorySet = new HashSet<>();
-        if (issueCodesForAllElementsDisputed.isEmpty()) {
-            log.info("Case {} has no elements disputed", caseData.getCcdCaseId());
-        }
-        for (String issueCode : issueCodesForAllElementsDisputed ) {
-            String individualUcBenefitIssueCode = caseData.getBenefitCode() + issueCode;
-            DefaultPanelComposition issueCodePanelComposition =  defaultPanelCompositions.stream()
-                    .filter(new DefaultPanelComposition(individualUcBenefitIssueCode, specialismCount, isFqpm, isMedicalMember)::equals)
-                    .findFirst().orElse(null);
-            if (nonNull(issueCodePanelComposition)) {
-                johTiersSet.addAll(issueCodePanelComposition.getJohTiers());
-                sessionCategorySet.add(issueCodePanelComposition.getCategory());
-                if (Issue.SG.toString().equals(issueCode) || (Issue.WC.toString().equals(issueCode))) {
-                    defaultPanelComposition.setCategory(issueCodePanelComposition.getCategory());
-                }
-            }
-        }
-        defaultPanelComposition.setJohTiers(new ArrayList<>(johTiersSet));
-        if (isNull(defaultPanelComposition.getCategory()) && !sessionCategorySet.isEmpty()) {
-            defaultPanelComposition.setCategory(sessionCategorySet.stream().findAny().get());
-        }
-        return defaultPanelComposition;
+    public List<String> getDefaultJohTiers(SscsCaseData caseData) {
+        return defaultPanelCompositions.stream()
+                .filter(new DefaultPanelComposition(caseData)::equals)
+                .findFirst().orElse(new DefaultPanelComposition())
+                .getJohTiers();
     }
 
     public boolean isBenefitIssueCodeValid(String benefitCode, String issueCode) {
         return defaultPanelCompositions.stream().anyMatch(panelComposition -> panelComposition.getBenefitIssueCode().equals(benefitCode + issueCode));
-    }
-
-    private void updatePanelCompositionFromSpecialismCount(SscsCaseData caseData) {
-        String specialismCount = getSpecialismCount(caseData);
-
-        if ("2".equals(specialismCount)) {
-            if (isNull(caseData.getPanelMemberComposition().getPanelCompositionMemberMedical1())) {
-                caseData.getPanelMemberComposition().setPanelCompositionMemberMedical1(TRIBUNAL_MEMBER_MEDICAL.toRef());
-            }
-            caseData.getPanelMemberComposition().setPanelCompositionMemberMedical2(TRIBUNAL_MEMBER_MEDICAL.toRef());
-        } else {
-            caseData.getPanelMemberComposition().setPanelCompositionMemberMedical2(null);
-        }
-    }
-
-    private String getSpecialismCount(SscsCaseData caseData) {
-        return caseData.getSscsIndustrialInjuriesData().getPanelDoctorSpecialism() != null
-                ? caseData.getSscsIndustrialInjuriesData().getSecondPanelDoctorSpecialism() != null
-                ? "2" : "1" : null;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionService.java
@@ -2,13 +2,16 @@ package uk.gov.hmcts.reform.sscs.reference.data.service;
 
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.reform.sscs.reference.data.helper.ReferenceDataHelper.getReferenceData;
+import static uk.gov.hmcts.reform.sscs.reference.data.model.DefaultPanelComposition.getSpecialismCount;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberComposition;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.reference.data.model.DefaultPanelComposition;
 
@@ -39,6 +42,14 @@ public class PanelCompositionService {
                 .filter(new DefaultPanelComposition(caseData)::equals)
                 .findFirst().orElse(new DefaultPanelComposition())
                 .getJohTiers();
+    }
+
+    public PanelMemberComposition resetPanelCompositionIfStale(SscsCaseData caseData, SscsCaseData caseDataBefore) {
+        boolean hasIssueCodeChanged = !caseData.getIssueCode().equals(caseDataBefore.getIssueCode());
+        boolean hasSpecialismCountChanged =
+                !Objects.equals(getSpecialismCount(caseData), getSpecialismCount(caseDataBefore));
+        return hasIssueCodeChanged || hasSpecialismCountChanged
+                ? new PanelMemberComposition() : caseData.getPanelMemberComposition();
     }
 
     public boolean isBenefitIssueCodeValid(String benefitCode, String issueCode) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionService.java
@@ -1,16 +1,21 @@
 package uk.gov.hmcts.reform.sscs.reference.data.service;
 
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.reform.sscs.reference.data.helper.ReferenceDataHelper.getReferenceData;
 import static uk.gov.hmcts.reform.sscs.reference.data.model.DefaultPanelComposition.getSpecialismCount;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Issue;
 import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberComposition;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.reference.data.model.DefaultPanelComposition;
@@ -30,16 +35,51 @@ public class PanelCompositionService {
     }
 
     public List<String> getRoleTypes(SscsCaseData caseData) {
+        List<String> johTiers;
         if (nonNull(caseData.getPanelMemberComposition()) && !caseData.getPanelMemberComposition().isEmpty()) {
-            return caseData.getPanelMemberComposition().getJohTiers();
+            johTiers = caseData.getPanelMemberComposition().getJohTiers();
+            log.info("Existing Panel Composition for case id: {} has JOH tiers: {}", caseData.getCcdCaseId(), johTiers);
         } else {
-            return getDefaultPanelComposition(caseData).getJohTiers();
+            johTiers = getDefaultPanelComposition(caseData).getJohTiers();
+            log.info("Default JOH tiers for case id {} have been calculated as: {}", caseData.getCcdCaseId(), johTiers);
         }
+        return johTiers;
     }
 
     public DefaultPanelComposition getDefaultPanelComposition(SscsCaseData caseData) {
+        if (List.of(Issue.UM.toString(), Issue.US.toString()).contains(caseData.getIssueCode())) {
+            log.info("Using Universal Credit default panel composition calculator for case {}",
+                    caseData.getCcdCaseId());
+            return getUcDefaultPanelComposition(caseData);
+        } else {
+            log.info("Using default panel composition calculator for case {}", caseData.getCcdCaseId());
+            return findDefaultPanelCompForIssueCode(caseData.getIssueCode(), caseData);
+        }
+    }
+
+    private DefaultPanelComposition getUcDefaultPanelComposition(SscsCaseData caseData) {
+        var defaultPanelComposition = new DefaultPanelComposition(caseData.getIssueCode(), caseData);
+        if (caseData.getIssueCodesForAllElementsDisputed().isEmpty()) {
+            log.info("Case {} has no elements disputed", caseData.getCcdCaseId());
+        }
+        Set<String> allElementsJohTiers = new HashSet<>();
+        caseData.getIssueCodesForAllElementsDisputed().forEach(issueCode -> {
+            DefaultPanelComposition issueCodePanelComposition =  findDefaultPanelCompForIssueCode(issueCode, caseData);
+            if (nonNull(issueCodePanelComposition)) {
+                allElementsJohTiers.addAll(issueCodePanelComposition.getJohTiers());
+                if (Issue.SG.toString().equals(issueCode) || Issue.WC.toString().equals(issueCode)
+                        || isNull(defaultPanelComposition.getCategory())) {
+                    defaultPanelComposition.setCategory(issueCodePanelComposition.getCategory());
+                }
+            }
+        });
+        defaultPanelComposition.setJohTiers(new ArrayList<>(allElementsJohTiers));
+        return defaultPanelComposition;
+    }
+
+    private DefaultPanelComposition findDefaultPanelCompForIssueCode(String issueCode, SscsCaseData caseData) {
         return defaultPanelCompositions.stream()
-                .filter(new DefaultPanelComposition(caseData)::equals)
+                .filter(new DefaultPanelComposition(issueCode, caseData)::equals)
                 .findFirst().orElse(new DefaultPanelComposition());
     }
 
@@ -52,6 +92,8 @@ public class PanelCompositionService {
     }
 
     public boolean isBenefitIssueCodeValid(String benefitCode, String issueCode) {
-        return defaultPanelCompositions.stream().anyMatch(panelComposition -> panelComposition.getBenefitIssueCode().equals(benefitCode + issueCode));
+        return defaultPanelCompositions.stream()
+                .anyMatch(panelComposition ->
+                        panelComposition.getBenefitIssueCode().equals(benefitCode + issueCode));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/EventTypeTest.java
@@ -228,7 +228,7 @@ public class EventTypeTest {
 
     @Test
     public void eventNameIsCorrect() {
-        List<EventType> exceptions = Arrays.asList(DWP_RESPOND, ADJOURNED,
+        List<EventType> exceptions = Arrays.asList(AMEND_SPECIALISM, DWP_RESPOND, ADJOURNED,
                 LAPSED_REVISED, WITHDRAWN, POSTPONED, DORMANT, CLOSED, DWP_RESPOND_OVERDUE,
                 SYA_APPEAL_CREATED, FIRST_HEARING_HOLDING_REMINDER, FINAL_DECISION, COH_ONLINE_HEARING_RELISTED,
                 SENT_TO_DWP_ERROR, REQUEST_FOR_INFORMATION, CREATE_APPEAL_PDF, RESEND_CASE_TO_GAPS2, ADD_SC_NUMBER,

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberCompositionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberCompositionTest.java
@@ -5,8 +5,17 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberComposition.FQPM_REF;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.DISTRICT_TRIBUNAL_JUDGE;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.REGIONAL_MEDICAL_MEMBER;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.TRIBUNAL_JUDGE;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.TRIBUNAL_MEMBER_DISABILITY;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.TRIBUNAL_MEMBER_MEDICAL;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -16,12 +25,112 @@ class PanelMemberCompositionTest {
 
     private static final String REGIONAL_MEDICAL_MEMBER_REF = PanelMemberType.REGIONAL_MEDICAL_MEMBER.toRef();
 
-    static Stream<List<String>> listsWithoutFqpm() {
-        return Stream.of(
-            new ArrayList<>(List.of("58", "44")),
-            new ArrayList<>(),
-            null
-        );
+    @DisplayName("Populate Panel composition from role types with No medical member")
+    @Test
+    public void createPanelCompositionFromJohTiersNoMedicalMember() {
+        var roleTypes = List.of(TRIBUNAL_JUDGE.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef(),
+                TRIBUNAL_MEMBER_DISABILITY.toRef());
+        var panelComposition = PanelMemberComposition.builder()
+                .panelCompositionJudge(TRIBUNAL_JUDGE.toRef())
+                .panelCompositionDisabilityAndFqMember(
+                        List.of(TRIBUNAL_MEMBER_DISABILITY.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef())
+                ).build();
+
+        var result = new PanelMemberComposition(roleTypes);
+
+        assertEqualsPanelComposition(panelComposition, result);
+    }
+
+    @DisplayName("Populate Panel composition from role types with one medical member")
+    @Test
+    public void createPanelCompositionFromJohTiersWithOneMedicalMember() {
+        var roleTypes = List.of(TRIBUNAL_JUDGE.toRef(), TRIBUNAL_MEMBER_MEDICAL.toRef(),
+                TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef(), TRIBUNAL_MEMBER_DISABILITY.toRef());
+        var panelComposition = PanelMemberComposition.builder()
+                .panelCompositionJudge(TRIBUNAL_JUDGE.toRef())
+                .panelCompositionMemberMedical1(TRIBUNAL_MEMBER_MEDICAL.toRef())
+                .panelCompositionDisabilityAndFqMember(
+                        List.of(TRIBUNAL_MEMBER_DISABILITY.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef())
+                ).build();
+
+        var result = new PanelMemberComposition(roleTypes);
+
+        assertEqualsPanelComposition(panelComposition, result);
+    }
+
+    @DisplayName("Get JOH tiers from panelComposition with tribunal judge")
+    @Test
+    public void shouldGetJohTiersFromPanelCompositionWithTribunalJudge() {
+        var johTiers = List.of(TRIBUNAL_JUDGE.toRef(), TRIBUNAL_MEMBER_MEDICAL.toRef(),
+                TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef(), TRIBUNAL_MEMBER_DISABILITY.toRef());
+        var panelComposition = PanelMemberComposition.builder()
+                .panelCompositionJudge(TRIBUNAL_JUDGE.toRef())
+                .panelCompositionMemberMedical1(TRIBUNAL_MEMBER_MEDICAL.toRef())
+                .panelCompositionDisabilityAndFqMember(
+                        List.of(TRIBUNAL_MEMBER_DISABILITY.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef())
+                ).build();
+
+        assertThat(panelComposition.getJohTiers()).containsAll(johTiers);
+    }
+
+    @DisplayName("Get JOH tiers from panelComposition with dtj and no fqpm")
+    @Test
+    public void shouldGetJohTiersFromPanelCompositionWithDtjAndNoFqpm() {
+        var johTiers =
+                List.of(TRIBUNAL_MEMBER_MEDICAL.toRef(), DISTRICT_TRIBUNAL_JUDGE.toRef(), TRIBUNAL_MEMBER_DISABILITY.toRef());
+        var panelComposition = PanelMemberComposition.builder()
+                .districtTribunalJudge(DISTRICT_TRIBUNAL_JUDGE.toRef())
+                .panelCompositionMemberMedical1(TRIBUNAL_MEMBER_MEDICAL.toRef())
+                .panelCompositionDisabilityAndFqMember(
+                        List.of(TRIBUNAL_MEMBER_DISABILITY.toRef())
+                ).build();
+
+        assertThat(panelComposition.getJohTiers()).containsAll(johTiers);
+    }
+
+    @DisplayName("Populate Panel composition from role types with two medical members")
+    @Test
+    public void createPanelCompositionFromJohTiersWithTwoMedicalMembers() {
+        var roleTypes = List.of(TRIBUNAL_JUDGE.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef(),
+                TRIBUNAL_MEMBER_MEDICAL.toRef(),TRIBUNAL_MEMBER_MEDICAL.toRef(), TRIBUNAL_MEMBER_DISABILITY.toRef());
+        var panelComposition = PanelMemberComposition.builder()
+                .panelCompositionJudge(TRIBUNAL_JUDGE.toRef())
+                .panelCompositionMemberMedical1(TRIBUNAL_MEMBER_MEDICAL.toRef())
+                .panelCompositionMemberMedical2(TRIBUNAL_MEMBER_MEDICAL.toRef())
+                .panelCompositionDisabilityAndFqMember(
+                        List.of(TRIBUNAL_MEMBER_DISABILITY.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef())
+                ).build();
+
+        var result = new PanelMemberComposition(roleTypes);
+
+        assertEqualsPanelComposition(panelComposition, result);
+    }
+
+    @DisplayName("Populate Panel composition from role types with regional and tribunal medical members")
+    @Test
+    public void createPanelCompositionFromJohTiersWithRegionalAndTribunalMedicalMembers() {
+        var roleTypes = List.of(DISTRICT_TRIBUNAL_JUDGE.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef(),
+                TRIBUNAL_MEMBER_MEDICAL.toRef(),REGIONAL_MEDICAL_MEMBER.toRef(), TRIBUNAL_MEMBER_DISABILITY.toRef());
+        var panelComposition = PanelMemberComposition.builder()
+                .districtTribunalJudge(DISTRICT_TRIBUNAL_JUDGE.toRef())
+                .panelCompositionMemberMedical1(REGIONAL_MEDICAL_MEMBER.toRef())
+                .panelCompositionMemberMedical2(TRIBUNAL_MEMBER_MEDICAL.toRef())
+                .panelCompositionDisabilityAndFqMember(
+                        List.of(TRIBUNAL_MEMBER_DISABILITY.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef())
+                ).build();
+
+        var result = new PanelMemberComposition(roleTypes);
+
+        assertEqualsPanelComposition(panelComposition, result);
+    }
+
+    private void assertEqualsPanelComposition(PanelMemberComposition expected, PanelMemberComposition actual) {
+        assertEquals(expected.getPanelCompositionJudge(), actual.getPanelCompositionJudge());
+        assertEquals(expected.getDistrictTribunalJudge(), actual.getDistrictTribunalJudge());
+        assertEquals(expected.getPanelCompositionJudge(), actual.getPanelCompositionJudge());
+        assertEquals(expected.getPanelCompositionMemberMedical1(), actual.getPanelCompositionMemberMedical1());
+        assertEquals(expected.getPanelCompositionMemberMedical2(), actual.getPanelCompositionMemberMedical2());
+        assertTrue(expected.getPanelCompositionDisabilityAndFqMember().containsAll(actual.getPanelCompositionDisabilityAndFqMember()));
     }
 
     @ParameterizedTest
@@ -130,5 +239,13 @@ class PanelMemberCompositionTest {
 
         assertThat(panelMemberComposition.getPanelCompositionMemberMedical1()).isNull();
         assertThat(panelMemberComposition.getPanelCompositionMemberMedical2()).isNull();
+    }
+
+    private static Stream<List<String>> listsWithoutFqpm() {
+        return Stream.of(
+                new ArrayList<>(List.of("58", "44")),
+                new ArrayList<>(),
+                null
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/model/DefaultPanelCompositionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/model/DefaultPanelCompositionTest.java
@@ -5,10 +5,16 @@ import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType;
 
 import java.util.List;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsIndustrialInjuriesData;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.REGIONAL_MEDICAL_MEMBER;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.TRIBUNAL_MEMBER_MEDICAL;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.NO;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.YES;
 
 public class DefaultPanelCompositionTest {
 
@@ -30,5 +36,43 @@ public class DefaultPanelCompositionTest {
         List<PanelMemberType> panelMembers = List.of(REGIONAL_MEDICAL_MEMBER);
         boolean result = defaultPanelComposition.containsAnyPanelMembers(panelMembers);
         assertThat(result).isFalse();
+    }
+
+    @DisplayName("Create DefaultPanelComposition with FQPM and no medical member")
+    @Test
+    public void shouldReturnDefaultPanelCompositionWithFqpmAndNoMedicalMember() {
+        var caseData = SscsCaseData.builder()
+                .benefitCode("022").issueCode("RA")
+                .sscsIndustrialInjuriesData(SscsIndustrialInjuriesData.builder()
+                        .panelDoctorSpecialism("cardiologist").build())
+                .isFqpmRequired(YES)
+                .isMedicalMemberRequired(NO)
+                .build();
+
+        var actual  = new DefaultPanelComposition(caseData);
+
+        assertEquals("022RA", actual.getBenefitIssueCode());
+        assertEquals("1", actual.getSpecialismCount());
+        assertEquals("yes", actual.getFqpm());
+        assertNull(actual.getMedicalMember());
+    }
+
+    @DisplayName("Create DefaultPanelComposition with  Medical member and no FQPM")
+    @Test
+    public void shouldReturnDefaultPanelCompositionWithMedicalMemberAndNoFqpm() {
+        var caseData = SscsCaseData.builder()
+                .benefitCode("022").issueCode("RA")
+                .sscsIndustrialInjuriesData(SscsIndustrialInjuriesData.builder()
+                        .panelDoctorSpecialism("cardiologist").secondPanelDoctorSpecialism("radiologist").build())
+                .isFqpmRequired(NO)
+                .isMedicalMemberRequired(YES)
+                .build();
+
+        var actual  = new DefaultPanelComposition(caseData);
+
+        assertEquals("022RA", actual.getBenefitIssueCode());
+        assertEquals("2", actual.getSpecialismCount());
+        assertEquals("yes", actual.getMedicalMember());
+        assertNull(actual.getFqpm());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/model/DefaultPanelCompositionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/model/DefaultPanelCompositionTest.java
@@ -49,7 +49,7 @@ public class DefaultPanelCompositionTest {
                 .isMedicalMemberRequired(NO)
                 .build();
 
-        var actual  = new DefaultPanelComposition(caseData);
+        var actual  = new DefaultPanelComposition(caseData.getIssueCode(), caseData);
 
         assertEquals("022RA", actual.getBenefitIssueCode());
         assertEquals("1", actual.getSpecialismCount());
@@ -68,7 +68,7 @@ public class DefaultPanelCompositionTest {
                 .isMedicalMemberRequired(YES)
                 .build();
 
-        var actual  = new DefaultPanelComposition(caseData);
+        var actual  = new DefaultPanelComposition(caseData.getIssueCode(), caseData);
 
         assertEquals("022RA", actual.getBenefitIssueCode());
         assertEquals("2", actual.getSpecialismCount());

--- a/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
@@ -23,11 +23,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberComposition;
-import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.ReserveTo;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsIndustrialInjuriesData;
-import uk.gov.hmcts.reform.sscs.reference.data.model.DefaultPanelComposition;
 
 public class PanelMemberCompositionServiceTest {
 
@@ -59,7 +57,8 @@ public class PanelMemberCompositionServiceTest {
     @Test
     public void shouldReturnPanelCompositionForValidIssueBenefitCode(){
         var defaultJohTiers = panelCompositionService
-                .getDefaultJohTiers(SscsCaseData.builder().benefitCode("001").issueCode("AD").build());
+                .getDefaultPanelComposition(SscsCaseData.builder().benefitCode("001").issueCode("AD").build())
+                .getJohTiers();
         var result = new PanelMemberComposition(defaultJohTiers);
 
         assertThat(result).isNotNull();
@@ -76,7 +75,8 @@ public class PanelMemberCompositionServiceTest {
     @DisplayName("should return emptyPanelComposition")
     @Test
     public void shouldReturnEmptyPanelComposition() {
-        var result = panelCompositionService.getDefaultJohTiers(buildCaseData());
+        var result = panelCompositionService.getDefaultPanelComposition(buildCaseData())
+                .getJohTiers();
         assertTrue(result.isEmpty());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
@@ -15,19 +15,20 @@ import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.TRIBUNAL_MEMBE
 import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.TRIBUNAL_MEMBER_MEDICAL;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.NO;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.YES;
-import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseData;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.ElementDisputed;
+import uk.gov.hmcts.reform.sscs.ccd.domain.ElementDisputedDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberComposition;
 import uk.gov.hmcts.reform.sscs.ccd.domain.ReserveTo;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsIndustrialInjuriesData;
 
-public class PanelMemberCompositionServiceTest {
+public class PanelCompositionServiceTest {
 
     private final PanelCompositionService panelCompositionService = new PanelCompositionService();
     private SscsCaseData caseData;
@@ -36,17 +37,17 @@ public class PanelMemberCompositionServiceTest {
     public void setUp() throws Exception {
         caseData = SscsCaseData.builder()
                 .sscsIndustrialInjuriesData(SscsIndustrialInjuriesData.builder().build())
-                .benefitCode("001")
+                .benefitCode("002")
                 .ccdCaseId("1234")
-                .issueCode("AD")
+                .issueCode("EI")
                 .build();
     }
 
-    @DisplayName("Valid call to gerRoleTypes should return correct johTier")
+    @DisplayName("Valid call to getRoleTypes should return correct johTier")
     @Test
     public void getDefaultPanelComposition(){
         var result = panelCompositionService
-                .getRoleTypes(SscsCaseData.builder().benefitCode("001").issueCode("AD").build());
+                .getRoleTypes(SscsCaseData.builder().benefitCode("002").issueCode("EI").build());
 
         assertThat(result).isNotNull();
         assertThat(result).isNotEmpty();
@@ -57,7 +58,7 @@ public class PanelMemberCompositionServiceTest {
     @Test
     public void shouldReturnPanelCompositionForValidIssueBenefitCode(){
         var defaultJohTiers = panelCompositionService
-                .getDefaultPanelComposition(SscsCaseData.builder().benefitCode("001").issueCode("AD").build())
+                .getDefaultPanelComposition(SscsCaseData.builder().benefitCode("002").issueCode("EI").build())
                 .getJohTiers();
         var result = new PanelMemberComposition(defaultJohTiers);
 
@@ -65,17 +66,65 @@ public class PanelMemberCompositionServiceTest {
         assertEquals(TRIBUNAL_JUDGE.toRef(), result.getPanelCompositionJudge());
     }
 
-    @DisplayName("Invalid call to gerRoleTypes should return null")
+    @DisplayName("Should return correct panelComposition for single UC issue benefit code combination")
+    @Test
+    public void shouldReturnPanelCompositionForValidSingleUcIssueBenefitCode(){
+
+        ElementDisputed disputedElement1 = ElementDisputed.builder().value(ElementDisputedDetails.builder().issueCode("CX").build())
+                .build();
+
+        SscsCaseData sscsCaseData = SscsCaseData.builder()
+                .elementsDisputedGeneral(List.of(disputedElement1))
+                .benefitCode("001").issueCode("US").build();
+
+        var defaultPanelComposition = panelCompositionService.getDefaultPanelComposition(sscsCaseData);
+        var result = new PanelMemberComposition(defaultPanelComposition.getJohTiers());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getPanelCompositionJudge()).isEqualTo(TRIBUNAL_JUDGE.toRef());
+        assertThat(result.getPanelCompositionMemberMedical1()).isNull();
+        assertThat(result.getPanelCompositionDisabilityAndFqMember()).isEmpty();
+        assertThat(defaultPanelComposition.getCategory()).isEqualTo("1");
+    }
+
+
+    @DisplayName("Should return correct panelComposition for multiple UC issue benefit code combination")
+    @Test
+    public void shouldReturnPanelCompositionForValidMultipleUcIssueBenefitCode(){
+
+        var disputedElement1 =
+                ElementDisputed.builder().value(ElementDisputedDetails.builder().issueCode("CX").build()).build();
+        var disputedElement2 =
+                ElementDisputed.builder().value(ElementDisputedDetails.builder().issueCode("SG").build()).build();
+        var disputedElement3 =
+                ElementDisputed.builder().value(ElementDisputedDetails.builder().issueCode("HT").build()).build();
+
+        SscsCaseData sscsCaseData = SscsCaseData.builder()
+                .elementsDisputedGeneral(List.of(disputedElement1, disputedElement2))
+                .elementsDisputedHousing(List.of(disputedElement3))
+                .benefitCode("001").issueCode("UM").build();
+
+        var defaultPanelComposition = panelCompositionService.getDefaultPanelComposition(sscsCaseData);
+        var result = new PanelMemberComposition(defaultPanelComposition.getJohTiers());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getPanelCompositionJudge()).isEqualTo(TRIBUNAL_JUDGE.toRef());
+        assertThat(result.getPanelCompositionMemberMedical1()).isEqualTo(TRIBUNAL_MEMBER_MEDICAL.toRef());
+        assertThat(result.getPanelCompositionDisabilityAndFqMember()).isEmpty();
+        assertThat(defaultPanelComposition.getCategory()).isEqualTo("4");
+    }
+
+    @DisplayName("Invalid call to getRoleTypes should return null")
     @Test
     public void getDefaultPanelCompositionWithInvalidParameters() {
-        var result = panelCompositionService.getRoleTypes(buildCaseData());
+        var result = panelCompositionService.getRoleTypes(SscsCaseData.builder().issueCode("DD").build());
         assertThat(result).isEmpty();
     }
 
     @DisplayName("should return emptyPanelComposition")
     @Test
     public void shouldReturnEmptyPanelComposition() {
-        var result = panelCompositionService.getDefaultPanelComposition(buildCaseData())
+        var result = panelCompositionService.getDefaultPanelComposition(SscsCaseData.builder().issueCode("DD").build())
                 .getJohTiers();
         assertTrue(result.isEmpty());
     }
@@ -195,7 +244,7 @@ public class PanelMemberCompositionServiceTest {
     public void getJohTiersFromPanelCompositionShouldReturnEmptyListWhenFieldsAreEmpty() {
         PanelMemberComposition panelMemberComposition = PanelMemberComposition.builder()
                 .panelCompositionDisabilityAndFqMember(new ArrayList<>()).build();
-        var caseData = buildCaseData();
+        var caseData = SscsCaseData.builder().issueCode("DD").build();
         caseData.setPanelMemberComposition(panelMemberComposition);
         List<String> result = panelCompositionService.getRoleTypes(caseData);
         assertThat(result).isEmpty();

--- a/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
@@ -14,20 +14,22 @@ import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.TRIBUNAL_MEMBE
 import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.TRIBUNAL_MEMBER_MEDICAL;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.NO;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.YES;
+import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseData;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import uk.gov.hmcts.reform.sscs.ccd.domain.ElementDisputed;
-import uk.gov.hmcts.reform.sscs.ccd.domain.ElementDisputedDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.PanelComposition;
 import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberComposition;
+import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.ReserveTo;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsIndustrialInjuriesData;
+import uk.gov.hmcts.reform.sscs.reference.data.model.DefaultPanelComposition;
 
-public class PanelCompositionServiceTest {
+public class PanelMemberCompositionServiceTest {
 
     private final PanelCompositionService panelCompositionService = new PanelCompositionService();
     private SscsCaseData caseData;
@@ -36,17 +38,17 @@ public class PanelCompositionServiceTest {
     public void setUp() throws Exception {
         caseData = SscsCaseData.builder()
                 .sscsIndustrialInjuriesData(SscsIndustrialInjuriesData.builder().build())
-                .benefitCode("002")
+                .benefitCode("001")
                 .ccdCaseId("1234")
-                .issueCode("EI")
+                .issueCode("AD")
                 .build();
     }
 
-    @DisplayName("Valid call to getRoleTypes should return correct johTier")
+    @DisplayName("Valid call to gerRoleTypes should return correct johTier")
     @Test
     public void getDefaultPanelComposition(){
         var result = panelCompositionService
-                .getRoleTypes(SscsCaseData.builder().benefitCode("002").issueCode("EI").build());
+                .getRoleTypes(SscsCaseData.builder().benefitCode("001").issueCode("AD").build());
 
         assertThat(result).isNotNull();
         assertThat(result).isNotEmpty();
@@ -56,72 +58,25 @@ public class PanelCompositionServiceTest {
     @DisplayName("Should return correct panelComposition for valid issue benefit code combination")
     @Test
     public void shouldReturnPanelCompositionForValidIssueBenefitCode(){
-        var result = panelCompositionService
-                .createPanelComposition(SscsCaseData.builder().benefitCode("002").issueCode("EI").build());
+        var defaultJohTiers = panelCompositionService
+                .getDefaultJohTiers(SscsCaseData.builder().benefitCode("001").issueCode("AD").build());
+        var result = new PanelMemberComposition(defaultJohTiers);
 
         assertThat(result).isNotNull();
         assertEquals(TRIBUNAL_JUDGE.toRef(), result.getPanelCompositionJudge());
     }
 
-    @DisplayName("Should return correct panelComposition for single UC issue benefit code combination")
-    @Test
-    public void shouldReturnPanelCompositionForValidSingleUcIssueBenefitCode(){
-
-        ElementDisputed disputedElement1 = ElementDisputed.builder().value(ElementDisputedDetails.builder().issueCode("CX").build())
-                .build();
-
-        SscsCaseData sscsCaseData = SscsCaseData.builder()
-                .elementsDisputedGeneral(List.of(disputedElement1))
-                .benefitCode("001").issueCode("US").build();
-
-        var defaultPanelComposition = panelCompositionService.getDefaultPanelComposition(sscsCaseData);
-        var result = panelCompositionService.createPanelComposition(sscsCaseData);
-
-        assertThat(result).isNotNull();
-        assertThat(result.getPanelCompositionJudge()).isEqualTo(TRIBUNAL_JUDGE.toRef());
-        assertThat(result.getPanelCompositionMemberMedical1()).isNull();
-        assertThat(result.getPanelCompositionDisabilityAndFqMember()).isEmpty();
-        assertThat(defaultPanelComposition.getCategory()).isEqualTo("1");
-    }
-
-
-    @DisplayName("Should return correct panelComposition for multiple UC issue benefit code combination")
-    @Test
-    public void shouldReturnPanelCompositionForValidMultipleUcIssueBenefitCode(){
-
-        ElementDisputed disputedElement1 = ElementDisputed.builder().value(ElementDisputedDetails.builder().issueCode("CX").build())
-                .build();
-        ElementDisputed disputedElement2 = ElementDisputed.builder().value(ElementDisputedDetails.builder().issueCode("SG").build())
-                .build();
-        ElementDisputed disputedElement3 = ElementDisputed.builder().value(ElementDisputedDetails.builder().issueCode("HT").build())
-                .build();
-
-        SscsCaseData sscsCaseData = SscsCaseData.builder()
-                .elementsDisputedGeneral(List.of(disputedElement1, disputedElement2))
-                .elementsDisputedHousing(List.of(disputedElement3))
-                .benefitCode("001").issueCode("UM").build();
-
-        var defaultPanelComposition = panelCompositionService.getDefaultPanelComposition(sscsCaseData);
-        var result = panelCompositionService.createPanelComposition(sscsCaseData);
-
-        assertThat(result).isNotNull();
-        assertThat(result.getPanelCompositionJudge()).isEqualTo(TRIBUNAL_JUDGE.toRef());
-        assertThat(result.getPanelCompositionMemberMedical1()).isEqualTo(TRIBUNAL_MEMBER_MEDICAL.toRef());
-        assertThat(result.getPanelCompositionDisabilityAndFqMember()).isEmpty();
-        assertThat(defaultPanelComposition.getCategory()).isEqualTo("4");
-    }
-
-    @DisplayName("Invalid call to getRoleTypes should return null")
+    @DisplayName("Invalid call to gerRoleTypes should return null")
     @Test
     public void getDefaultPanelCompositionWithInvalidParameters() {
-        var result = panelCompositionService.getRoleTypes(SscsCaseData.builder().issueCode("DD").build());
+        var result = panelCompositionService.getRoleTypes(buildCaseData());
         assertThat(result).isEmpty();
     }
 
     @DisplayName("should return emptyPanelComposition")
     @Test
     public void shouldReturnEmptyPanelComposition() {
-        var result = panelCompositionService.createPanelComposition(SscsCaseData.builder().issueCode("DD").build());
+        var result = panelCompositionService.getDefaultJohTiers(buildCaseData());
         assertTrue(result.isEmpty());
     }
 
@@ -201,7 +156,7 @@ public class PanelCompositionServiceTest {
     @Test
     public void testGetRolesWithSavePanelComposition() {
         var updatedPanelMemberComposition =
-                panelCompositionService.createPanelCompositionFromJohTiers(List.of(TRIBUNAL_JUDGE.toRef()));
+                new PanelMemberComposition(List.of(TRIBUNAL_JUDGE.toRef()));
 
         assertEquals(TRIBUNAL_JUDGE.toRef(), updatedPanelMemberComposition.getPanelCompositionJudge());
     }
@@ -249,7 +204,7 @@ public class PanelCompositionServiceTest {
     public void getJohTiersFromPanelCompositionShouldReturnEmptyListWhenFieldsAreEmpty() {
         PanelMemberComposition panelMemberComposition = PanelMemberComposition.builder()
                 .panelCompositionDisabilityAndFqMember(new ArrayList<>()).build();
-        var caseData = SscsCaseData.builder().issueCode("DD").build();
+        var caseData = buildCaseData();
         caseData.setPanelMemberComposition(panelMemberComposition);
         List<String> result = panelCompositionService.getRoleTypes(caseData);
         assertThat(result).isEmpty();
@@ -334,7 +289,7 @@ public class PanelCompositionServiceTest {
                         List.of(TRIBUNAL_MEMBER_DISABILITY.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef())
                 ).build();
 
-        var result = panelCompositionService.createPanelCompositionFromJohTiers(roleTypes);
+        var result = new PanelMemberComposition(roleTypes);
 
         assertEqualsPanelComposition(panelComposition, result);
     }
@@ -351,7 +306,7 @@ public class PanelCompositionServiceTest {
                         List.of(TRIBUNAL_MEMBER_DISABILITY.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef())
                 ).build();
 
-        var result = panelCompositionService.createPanelCompositionFromJohTiers(roleTypes);
+        var result = new PanelMemberComposition(roleTypes);
 
         assertEqualsPanelComposition(panelComposition, result);
     }
@@ -369,7 +324,7 @@ public class PanelCompositionServiceTest {
                         List.of(TRIBUNAL_MEMBER_DISABILITY.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef())
                 ).build();
 
-        var result = panelCompositionService.createPanelCompositionFromJohTiers(roleTypes);
+        var result = new PanelMemberComposition(roleTypes);
 
         assertEqualsPanelComposition(panelComposition, result);
     }
@@ -387,7 +342,7 @@ public class PanelCompositionServiceTest {
                         List.of(TRIBUNAL_MEMBER_DISABILITY.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef())
                 ).build();
 
-        var result = panelCompositionService.createPanelCompositionFromJohTiers(roleTypes);
+        var result = new PanelMemberComposition(roleTypes);
 
         assertEqualsPanelComposition(panelComposition, result);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
@@ -4,6 +4,7 @@ import static java.util.Collections.frequency;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.DISTRICT_TRIBUNAL_JUDGE;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import uk.gov.hmcts.reform.sscs.ccd.domain.PanelComposition;
 import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberComposition;
 import uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.ReserveTo;
@@ -221,28 +220,11 @@ public class PanelMemberCompositionServiceTest {
         assertThat(result).isEqualTo(List.of("84"));
     }
 
-    @DisplayName("getRoleTypes should return an empty list when there is nothing to map")
-    @Test
-    public void getRoleTypesShouldReturnDtjWhenPanelCompositionFieldsAreEmptyButReserveTpDistrictJudgeSelected() {
-        PanelMemberComposition panelMemberComposition = PanelMemberComposition.builder()
-                .panelCompositionDisabilityAndFqMember(new ArrayList<>()).build();
-        caseData.getSchedulingAndListingFields()
-                .setReserveTo(ReserveTo.builder().reservedDistrictTribunalJudge(YES).build());
-        caseData.setPanelMemberComposition(panelMemberComposition);
-
-        List<String> result = panelCompositionService.getRoleTypes(caseData);
-
-        assertThat(result).isNotNull();
-        assertThat(result).isEqualTo(List.of("90000"));
-    }
-
     @DisplayName("createPanelCompositionFromJohTiers should return a district tribunal judge when they are reserved")
     @Test
     public void getJohTiersFromPanelCompositionShouldReturnDtjWhenItIsReserved() {
         PanelMemberComposition panelMemberComposition =
-                PanelMemberComposition.builder().panelCompositionJudge(TRIBUNAL_JUDGE.toRef()).build();
-        caseData.getSchedulingAndListingFields().setReserveTo(ReserveTo.builder()
-                .reservedDistrictTribunalJudge(YES).build());
+                PanelMemberComposition.builder().districtTribunalJudge(DISTRICT_TRIBUNAL_JUDGE.toRef()).build();
         caseData.setPanelMemberComposition(panelMemberComposition);
 
         List<String> result = panelCompositionService.getRoleTypes(caseData);
@@ -265,11 +247,10 @@ public class PanelMemberCompositionServiceTest {
     @Test
     public void getJohTiersFromPanelCompositionShouldReturnFqpmAndDisabilityList() {
         PanelMemberComposition panelMemberComposition = PanelMemberComposition.builder()
+                .districtTribunalJudge(DISTRICT_TRIBUNAL_JUDGE.toRef())
                 .panelCompositionDisabilityAndFqMember(
                         List.of(TRIBUNAL_MEMBER_DISABILITY.toRef(), TRIBUNAL_MEMBER_FINANCIALLY_QUALIFIED.toRef())
                 ).build();
-        caseData.getSchedulingAndListingFields().setReserveTo(ReserveTo.builder()
-                .reservedDistrictTribunalJudge(YES).build());
         caseData.setPanelMemberComposition(panelMemberComposition);
 
         List<String> result = panelCompositionService.getRoleTypes(caseData);
@@ -345,44 +326,6 @@ public class PanelMemberCompositionServiceTest {
         var result = new PanelMemberComposition(roleTypes);
 
         assertEqualsPanelComposition(panelComposition, result);
-    }
-
-    @Test
-    public void resetMedicalMembersWhenSpecialismCountIsChangedFromTwoToOne() {
-        PanelMemberComposition panelMemberComposition = PanelMemberComposition.builder().panelCompositionJudge("84")
-                .panelCompositionMemberMedical1("58")
-                .panelCompositionMemberMedical2("58")
-                .panelCompositionDisabilityAndFqMember(List.of("44")).build();
-        caseData.setPanelMemberComposition(panelMemberComposition);
-        caseData.getSscsIndustrialInjuriesData().setPanelDoctorSpecialism("dummy");
-        List<String> result = panelCompositionService.getRoleTypes(caseData);
-        assertThat(result).isNotNull();
-        assertThat(result).isEqualTo(List.of("84","58","44"));
-    }
-
-    @Test
-    public void resetMedicalMembersWhenSpecialismCountIsChangedFromOneToTwo() {
-        PanelMemberComposition panelMemberComposition = PanelMemberComposition.builder().panelCompositionJudge("84")
-                .panelCompositionMemberMedical1("58")
-                .panelCompositionDisabilityAndFqMember(List.of("44")).build();
-        caseData.setPanelMemberComposition(panelMemberComposition);
-        caseData.getSscsIndustrialInjuriesData().setPanelDoctorSpecialism("dummy");
-        caseData.getSscsIndustrialInjuriesData().setSecondPanelDoctorSpecialism("dummy");
-        List<String> result = panelCompositionService.getRoleTypes(caseData);
-        assertThat(result).isNotNull();
-        assertThat(result).isEqualTo(List.of("84","58","58","44"));
-    }
-
-    @Test
-    public void resetMedicalMembersWhenSpecialismCountIsChangedFromOneToTwoWithNoMedicalMember() {
-        PanelMemberComposition panelMemberComposition = PanelMemberComposition.builder().panelCompositionJudge("84")
-                .panelCompositionDisabilityAndFqMember(List.of("44")).build();
-        caseData.setPanelMemberComposition(panelMemberComposition);
-        caseData.getSscsIndustrialInjuriesData().setPanelDoctorSpecialism("dummy");
-        caseData.getSscsIndustrialInjuriesData().setSecondPanelDoctorSpecialism("dummy");
-        List<String> result = panelCompositionService.getRoleTypes(caseData);
-        assertThat(result).isNotNull();
-        assertThat(result).isEqualTo(List.of("84","58","58","44"));
     }
 
     private void assertEqualsPanelComposition(PanelMemberComposition expected, PanelMemberComposition actual) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/PanelCompositionServiceTest.java
@@ -323,11 +323,24 @@ public class PanelCompositionServiceTest {
         assertEquals(EMPTY_LIST, result.getJohTiers());
     }
 
+    @DisplayName("resetPanelCompositionIfStale should reset panelComp if benefitCode changes")
+    @Test
+    public void resetPanelCompositionIfStaleShouldResetPanelCompIfBenefitCodeChanges() {
+        var sscsCaseData = SscsCaseData.builder().benefitCode("022").build();
+        var sscsCaseDataBefore = SscsCaseData.builder().benefitCode("002").build();
+        sscsCaseData.setPanelMemberComposition(PanelMemberComposition.builder()
+                .panelCompositionJudge("84").build());
+
+        var result = panelCompositionService.resetPanelCompositionIfStale(sscsCaseData, sscsCaseDataBefore);
+
+        assertEquals(EMPTY_LIST, result.getJohTiers());
+    }
+
     @DisplayName("resetPanelCompositionIfStale should reset panelComp if issueCode changes")
     @Test
     public void resetPanelCompositionIfStaleShouldResetPanelCompIfIssueCodeChanges() {
-        var sscsCaseData = SscsCaseData.builder().issueCode("002").build();
-        var sscsCaseDataBefore = SscsCaseData.builder().issueCode("022").build();
+        var sscsCaseData = SscsCaseData.builder().issueCode("RA").build();
+        var sscsCaseDataBefore = SscsCaseData.builder().issueCode("CC").build();
         sscsCaseData.setPanelMemberComposition(PanelMemberComposition.builder()
                 .panelCompositionJudge("84").build());
 
@@ -339,9 +352,9 @@ public class PanelCompositionServiceTest {
     @DisplayName("resetPanelCompositionIfStale should reset panelComp if specialism changes")
     @Test
     public void resetPanelCompositionIfStaleShouldResetPanelCompIfSpecialismChanges() {
-        var sscsCaseData = SscsCaseData.builder().issueCode("022").sscsIndustrialInjuriesData(
+        var sscsCaseData = SscsCaseData.builder().sscsIndustrialInjuriesData(
                 SscsIndustrialInjuriesData.builder().panelDoctorSpecialism("doctor").build()).build();
-        var sscsCaseDataBefore = SscsCaseData.builder().issueCode("022").build();
+        var sscsCaseDataBefore = SscsCaseData.builder().build();
         sscsCaseData.setPanelMemberComposition(PanelMemberComposition.builder()
                 .panelCompositionJudge("84").build());
 
@@ -353,10 +366,12 @@ public class PanelCompositionServiceTest {
     @DisplayName("resetPanelCompositionIfStale should not reset panelComp if nothing changes")
     @Test
     public void resetPanelCompositionIfStaleShouldResetPanelCompIfNothingChanges() {
-        var sscsCaseData = SscsCaseData.builder().isFqpmRequired(YES).issueCode("022").sscsIndustrialInjuriesData(
-                SscsIndustrialInjuriesData.builder().panelDoctorSpecialism("doctor").build()).build();
-        var sscsCaseDataBefore = SscsCaseData.builder().isFqpmRequired(NO).issueCode("022").sscsIndustrialInjuriesData(
-                SscsIndustrialInjuriesData.builder().panelDoctorSpecialism("doctor").build()).build();
+        var sscsCaseData = SscsCaseData.builder().isFqpmRequired(YES).benefitCode("022").issueCode("RA")
+                .sscsIndustrialInjuriesData(SscsIndustrialInjuriesData.builder().panelDoctorSpecialism("doctor")
+                        .build()).build();
+        var sscsCaseDataBefore = SscsCaseData.builder().isFqpmRequired(NO).benefitCode("022").issueCode("RA")
+                .sscsIndustrialInjuriesData(SscsIndustrialInjuriesData.builder().panelDoctorSpecialism("doctor")
+                        .build()).build();
         sscsCaseData.setPanelMemberComposition(PanelMemberComposition.builder()
                 .panelCompositionJudge("84").panelCompositionMemberMedical1("58").build());
 


### PR DESCRIPTION
### Jira link
See [SSCSCI-1945](https://tools.hmcts.net/jira/browse/SSCSCI-1945)

### Change description
- simplify and consolidate panelComposition calculation logic
- reset panelComposition when issueCode/specialismsCount change

### Testing done


### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
