### PR TITLE
SSCSCI-1729: add equals method to PanelMemberComposition

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberComposition.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberComposition.java
@@ -9,7 +9,9 @@ import static uk.gov.hmcts.reform.sscs.ccd.domain.PanelMemberType.getPanelMember
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -31,6 +33,22 @@ public class PanelMemberComposition {
     private String panelCompositionMemberMedical2;
     private List<String> panelCompositionDisabilityAndFqMember = new ArrayList<>();
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PanelMemberComposition that = (PanelMemberComposition) o;
+        return Objects.equals(districtTribunalJudge, that.districtTribunalJudge)
+                && Objects.equals(panelCompositionJudge, that.panelCompositionJudge)
+                && Objects.equals(panelCompositionMemberMedical1, that.panelCompositionMemberMedical1)
+                && Objects.equals(panelCompositionMemberMedical2, that.panelCompositionMemberMedical2)
+                && new HashSet<>(panelCompositionDisabilityAndFqMember)
+                .containsAll(that.panelCompositionDisabilityAndFqMember);
+    }
 
     public PanelMemberComposition(List<String> johTiers) {
         for (String johTier : johTiers) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/SscsCaseData.java
@@ -40,8 +40,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType;
 import uk.gov.hmcts.reform.sscs.ccd.validation.groups.UniversalCreditValidationGroup;
@@ -421,7 +419,7 @@ public class SscsCaseData implements CaseData {
 
     @JsonIgnore
     private EventDetails getLatestEvent() {
-        return events != null && !events.isEmpty() ? events.get(0).getValue() : null;
+        return events != null && !events.isEmpty() ? events.getFirst().getValue() : null;
     }
 
     public ExtendedSscsCaseData getExtendedSscsCaseData() {
@@ -448,7 +446,7 @@ public class SscsCaseData implements CaseData {
         if (isNotEmpty(hearings)) {
             List<Hearing> sortedHearings = new ArrayList<>(hearings);
             sortedHearings.sort(Collections.reverseOrder());
-            return sortedHearings.get(0);
+            return sortedHearings.getFirst();
         }
         return null;
     }
@@ -552,13 +550,13 @@ public class SscsCaseData implements CaseData {
 
     @JsonIgnore
     private boolean stringToBoolean(String value) {
-        return StringUtils.equalsIgnoreCase("yes", value);
+        return "yes".equalsIgnoreCase(value);
     }
 
     @JsonIgnore
     public SscsDocument getLatestDocumentForDocumentType(DocumentType documentType) {
 
-        if (getSscsDocument() != null && getSscsDocument().size() > 0) {
+        if (getSscsDocument() != null && !getSscsDocument().isEmpty()) {
             Stream<SscsDocument> filteredStream = getSscsDocument().stream()
                     .filter(f -> documentType.getValue().equals(f.getValue().getDocumentType()));
 
@@ -573,10 +571,10 @@ public class SscsCaseData implements CaseData {
                     return -1;
                 }
                 return -1 * one.getValue().getDocumentDateAdded().compareTo(two.getValue().getDocumentDateAdded());
-            }).collect(Collectors.toList());
+            }).toList();
 
             if (!filteredList.isEmpty()) {
-                return filteredList.get(0);
+                return filteredList.getFirst();
             }
         }
         return null;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberCompositionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelMemberCompositionTest.java
@@ -123,15 +123,6 @@ class PanelMemberCompositionTest {
         assertEqualsPanelComposition(panelComposition, result);
     }
 
-    private void assertEqualsPanelComposition(PanelMemberComposition expected, PanelMemberComposition actual) {
-        assertEquals(expected.getPanelCompositionJudge(), actual.getPanelCompositionJudge());
-        assertEquals(expected.getDistrictTribunalJudge(), actual.getDistrictTribunalJudge());
-        assertEquals(expected.getPanelCompositionJudge(), actual.getPanelCompositionJudge());
-        assertEquals(expected.getPanelCompositionMemberMedical1(), actual.getPanelCompositionMemberMedical1());
-        assertEquals(expected.getPanelCompositionMemberMedical2(), actual.getPanelCompositionMemberMedical2());
-        assertTrue(expected.getPanelCompositionDisabilityAndFqMember().containsAll(actual.getPanelCompositionDisabilityAndFqMember()));
-    }
-
     @ParameterizedTest
     @MethodSource("listsWithoutFqpm")
     void hasFqpm_shouldReturnFalse_whenFqpmNotPresent(List<String> disabilityAndFqpm) {
@@ -238,6 +229,110 @@ class PanelMemberCompositionTest {
 
         assertThat(panelMemberComposition.getPanelCompositionMemberMedical1()).isNull();
         assertThat(panelMemberComposition.getPanelCompositionMemberMedical2()).isNull();
+    }
+
+    @Test
+    void equals_shouldReturnTrueForIdenticalObjects() {
+        PanelMemberComposition a = PanelMemberComposition.builder()
+                .districtTribunalJudge("dtj")
+                .panelCompositionJudge("judge")
+                .panelCompositionMemberMedical1("med1")
+                .panelCompositionMemberMedical2("med2")
+                .panelCompositionDisabilityAndFqMember(List.of("dis1", "fq1"))
+                .build();
+
+        PanelMemberComposition b = PanelMemberComposition.builder()
+                .districtTribunalJudge("dtj")
+                .panelCompositionJudge("judge")
+                .panelCompositionMemberMedical1("med1")
+                .panelCompositionMemberMedical2("med2")
+                .panelCompositionDisabilityAndFqMember(List.of("dis1", "fq1"))
+                .build();
+
+        assertThat(a.equals(b)).isTrue();
+    }
+
+    @Test
+    void equals_shouldReturnFalseForDifferentFields() {
+        PanelMemberComposition a = PanelMemberComposition.builder()
+                .districtTribunalJudge("dtj")
+                .panelCompositionJudge("judge")
+                .panelCompositionMemberMedical1("med1")
+                .panelCompositionMemberMedical2("med2")
+                .panelCompositionDisabilityAndFqMember(List.of("dis1", "fq1"))
+                .build();
+
+        PanelMemberComposition b = PanelMemberComposition.builder()
+                .districtTribunalJudge("dtj2")
+                .panelCompositionJudge("judge")
+                .panelCompositionMemberMedical1("med1")
+                .panelCompositionMemberMedical2("med2")
+                .panelCompositionDisabilityAndFqMember(List.of("dis1", "fq1"))
+                .build();
+
+        assertThat(a.equals(b)).isFalse();
+    }
+
+    @Test
+    void equals_shouldReturnTrueForSameReference() {
+        PanelMemberComposition a = PanelMemberComposition.builder()
+                .districtTribunalJudge("dtj")
+                .build();
+
+        assertThat(a.equals(a)).isTrue();
+    }
+
+    @Test
+    void equals_shouldReturnFalseForNull() {
+        PanelMemberComposition a = PanelMemberComposition.builder()
+                .districtTribunalJudge("dtj")
+                .build();
+
+        assertThat(a.equals(null)).isFalse();
+    }
+
+    @Test
+    void equals_shouldReturnFalseForDifferentClass() {
+        PanelMemberComposition a = PanelMemberComposition.builder()
+                .districtTribunalJudge("dtj")
+                .build();
+
+        assertThat(a.equals("not a PanelMemberComposition")).isFalse();
+    }
+
+    @Test
+    void equals_shouldIgnoreOrderOfDisabilityAndFqMember() {
+        PanelMemberComposition a = PanelMemberComposition.builder()
+                .panelCompositionDisabilityAndFqMember(List.of("a", "b"))
+                .build();
+
+        PanelMemberComposition b = PanelMemberComposition.builder()
+                .panelCompositionDisabilityAndFqMember(List.of("b", "a"))
+                .build();
+
+        assertThat(a.equals(b)).isTrue();
+    }
+
+    @Test
+    void equals_shouldReturnTrueForBothEmptyDisabilityAndFqMember() {
+        PanelMemberComposition a = PanelMemberComposition.builder()
+                .panelCompositionDisabilityAndFqMember(new ArrayList<>())
+                .build();
+
+        PanelMemberComposition b = PanelMemberComposition.builder()
+                .panelCompositionDisabilityAndFqMember(new ArrayList<>())
+                .build();
+
+        assertThat(a.equals(b)).isTrue();
+    }
+
+    private void assertEqualsPanelComposition(PanelMemberComposition expected, PanelMemberComposition actual) {
+        assertEquals(expected.getPanelCompositionJudge(), actual.getPanelCompositionJudge());
+        assertEquals(expected.getDistrictTribunalJudge(), actual.getDistrictTribunalJudge());
+        assertEquals(expected.getPanelCompositionJudge(), actual.getPanelCompositionJudge());
+        assertEquals(expected.getPanelCompositionMemberMedical1(), actual.getPanelCompositionMemberMedical1());
+        assertEquals(expected.getPanelCompositionMemberMedical2(), actual.getPanelCompositionMemberMedical2());
+        assertTrue(expected.getPanelCompositionDisabilityAndFqMember().containsAll(actual.getPanelCompositionDisabilityAndFqMember()));
     }
 
     private static Stream<List<String>> listsWithoutFqpm() {


### PR DESCRIPTION
### Jira link
- See [SSCSCI-1729](https://tools.hmcts.net/jira/browse/SSCSCI-1729)

### Change description
-  add equals method to PanelMemberComposition to ensure consistent equality check

### Testing done
- regression testing will be done one ULR code that uses equality

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
