### PR TITLE
SSCSCI-2440: java logging bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,11 @@ repositories {
 // region static code analysis
 
 checkstyle {
-    toolVersion = "11.1.0"
+    toolVersion = "13.4.0"
 }
 
 pmd {
-    toolVersion = "7.17.0"
+    toolVersion = "7.22.0"
     ignoreFailures = true
     sourceSets = [sourceSets.main, sourceSets.test]
     reportsDir = layout.buildDirectory.dir("reports/pmd").get().asFile
@@ -259,8 +259,17 @@ dependencies {
     // CVE-2024-25710
     implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.28.0'
 
-    // CVE-2023-2976, CVE-2020-8908
-    checkstyle group: 'com.puppycrawl.tools', name: 'checkstyle', version: checkstyle.toolVersion
-    checkstyle group: 'com.google.guava', name: 'guava', version: '33.5.0-jre'
-    checkstyle group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
+    constraints {
+        // CVE-2025-48924
+        checkstyle group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
+
+        // CVE-2025-67030
+        checkstyle group: 'org.codehaus.plexus', name: 'plexus-utils', version: '4.0.3'
+
+        // CVE-2025-68161
+        implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.25.3'
+        implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.25.3'
+
+        // CVE-2026-28338
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,7 @@ dependencies {
     implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.12'
     implementation group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
 
-    implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
+    implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
     implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.2.0'
 
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springboot

--- a/build.gradle
+++ b/build.gradle
@@ -253,13 +253,13 @@ dependencies {
     testImplementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
-    // CVE-2023-24998
-    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
-
-    // CVE-2024-25710
-    implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.28.0'
-
     constraints {
+        // CVE-2023-24998
+        implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
+
+        // CVE-2024-25710
+        implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.28.0'
+
         // CVE-2025-48924
         checkstyle group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
 
@@ -269,7 +269,5 @@ dependencies {
         // CVE-2025-68161
         implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.25.3'
         implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.25.3'
-
-        // CVE-2026-28338
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelCompositionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/PanelCompositionTest.java
@@ -16,7 +16,7 @@ public class PanelCompositionTest {
         "JUDGE_DOCTOR_AND_DISABILITY_EXPERT_IF_APPLICABLE, judge\\, doctor and disability expert (if applicable), barnwr\\, meddyg ac arbenigwr anabledd (os yw’n berthnasol)",
         "JUDGE_AND_ONE_OR_TWO_DOCTORS, judge and 1 or 2 doctors, barnwr ac 1 neu 2 feddyg",
         "JUDGE_AND_FINANCIALLY_QUALIFIED_PANEL_MEMBER, judge and Financially Qualified Panel Member (if applicable), Barnwr ac Aelod Panel sydd â chymhwyster i ddelio gyda materion Ariannol (os yw’n berthnasol)",
-         "JUDGE_AND_DOCTOR_IF_APPLICABLE, judge and doctor (if applicable), barnwr a meddyg (os yw’n berthnasol)",
+        "JUDGE_AND_DOCTOR_IF_APPLICABLE, judge and doctor (if applicable), barnwr a meddyg (os yw’n berthnasol)",
         "IBC_PANEL_COMPOSITION, judge and if applicable a medical member and/or a financially qualified tribunal member, barnwr ac os yw’n berthnasol aelod meddygol a/neu aelod o’r tribiwnlys sy’n gymwys mewn materion ariannol"}
     )
     public void assertAllValues(String row) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/VerbalLanguagesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/reference/data/service/VerbalLanguagesServiceTest.java
@@ -74,10 +74,10 @@ public class VerbalLanguagesServiceTest {
     @DisplayName("Dialect should be used for lookup when it exists")
     @ParameterizedTest
     @CsvSource({
-            "Bardini, kur-kbr", "Kurdish (Bardini), kur-kbr", "Kurdish Bardini, kur-kbr",
-            "Kurmanji, kur-kkr", "Kurdish (Kurmanji), kur-kkr", "Kurdish Kurmanji, kur-kkr",
-            "Sorani, kur-ksr", "Kurdish (Sorani), kur-ksr", "Kurdish Sorani, kur-ksr",
-            "Latvian, lav", "Lithuanian, lit", "Macedonian, mkd", "Flemish, nld-nfl"
+        "Bardini, kur-kbr", "Kurdish (Bardini), kur-kbr", "Kurdish Bardini, kur-kbr",
+        "Kurmanji, kur-kkr", "Kurdish (Kurmanji), kur-kkr", "Kurdish Kurmanji, kur-kkr",
+        "Sorani, kur-ksr", "Kurdish (Sorani), kur-ksr", "Kurdish Sorani, kur-ksr",
+        "Latvian, lav", "Lithuanian, lit", "Macedonian, mkd", "Flemish, nld-nfl"
     })
     public void shouldOnlyFindLanguageUsingDialectWhenItExists(String ccdRef, String hmcRef) {
         var language = languagesService.getVerbalLanguage(ccdRef);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/VenueDataLoaderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/VenueDataLoaderTest.java
@@ -69,7 +69,7 @@ public class VenueDataLoaderTest {
                         assertTrue(
                             venueDetails.getActive().contains(venueDetails.getComments().isEmpty() ? "Yes" : "No"),
                             format("%s is incorrect", venueDetails.getVenueId()))
-                );
+        );
     }
 
     @Test


### PR DESCRIPTION
### Jira link

See [SSCSCI-2440](https://tools.hmcts.net/jira/browse/SSCSCI-2440)

### Change description

| Name | Change |
| --- | --- |
| [java-logging](https://github.com/hmcts/java-logging) | `6.1.9` -> `8.0.0` |
| [checkstyle](https://checkstyle.sourceforge.io/) | `11.1.0` -> `13.4.0` |
| [pmd](https://pmd.github.io/) | `7.17.0` -> `7.22.0` |
| [plexus](https://codehaus-plexus.github.io/) | `3.3.0` -> `4.0.3` |
| [log4j](https://logging.apache.org/log4j/2.x/index.html) | `2.24.3` -> `2.25.3` |

Resolving CVEs:

CVE-2025-68161: `log4j` is a transitive dependency via Spring Boot
CVE-2025-67030: `plexus-utils` is a transitive dependency via `checkstyle` and is used exclusively by `checkstyle`
CVE-2026-28338: `pmd` update

### Testing done

Tested with tribunals [PR-5197](https://github.com/hmcts/sscs-tribunals-case-api/pull/5197/)

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
