### PR TITLE
Remove London Tribunals legacy venue

### DIFF
--- a/src/main/resources/reference-data/sscs-venues.csv
+++ b/src/main/resources/reference-data/sscs-venues.csv
@@ -267,4 +267,4 @@
 "1259","SC228","SSCS Leeds","Newcastle Civil and Family Courts & Tribunal Centre","Barras Bridge","","Newcastle upon Tyne","","NE1 8QF","",101,"https://maps.google.com/maps?q=54.978706,-1.609995","Yes","Newcastle Civic",,"","366796"
 "1261","SC338","SSCS Glasgow","Kilmarnock (Grand Hall)","Grand Hall","9 Green Street","East Ayrshire","Kilmarnock","KA1 3BN","",501,"https://goo.gl/maps/dV5v3JCXeu6BPBcB6","No","ZZ D U - Kilmarnock (Grand Hall)",,"Not active","000000"
 1270,SC400,SSCS Belfast,"Royal Courts of Justice, Belfast",Chichester Street,,Belfast,,BT1 3JF,,501,https://maps.app.goo.gl/zA41GcGzLUD5zQ4r6,Yes,Belfast RCJ,,,824367
-"1269","SC340","SSCS Sutton","London Tribunals","7 NEWGATE STREET",,"London",,"EC1A 7AZ",,,"https://www.google.com/maps/place/7+Newgate+St,+London+EC1A+7AE/@51.5157644,-0.1010494,670m","Yes","London Tribunals Centre","",,"369230"
+"1269","SC340","SSCS Sutton","London Tribunals","7 NEWGATE STREET",,"London",,"EC1A 7AZ",,,"https://www.google.com/maps/place/7+Newgate+St,+London+EC1A+7AE/@51.5157644,-0.1010494,670m","Yes","London Tribunals Centre",,,"369230"

--- a/src/main/resources/reference-data/sscs-venues.csv
+++ b/src/main/resources/reference-data/sscs-venues.csv
@@ -267,4 +267,4 @@
 "1259","SC228","SSCS Leeds","Newcastle Civil and Family Courts & Tribunal Centre","Barras Bridge","","Newcastle upon Tyne","","NE1 8QF","",101,"https://maps.google.com/maps?q=54.978706,-1.609995","Yes","Newcastle Civic",,"","366796"
 "1261","SC338","SSCS Glasgow","Kilmarnock (Grand Hall)","Grand Hall","9 Green Street","East Ayrshire","Kilmarnock","KA1 3BN","",501,"https://goo.gl/maps/dV5v3JCXeu6BPBcB6","No","ZZ D U - Kilmarnock (Grand Hall)",,"Not active","000000"
 1270,SC400,SSCS Belfast,"Royal Courts of Justice, Belfast",Chichester Street,,Belfast,,BT1 3JF,,501,https://maps.app.goo.gl/zA41GcGzLUD5zQ4r6,Yes,Belfast RCJ,,,824367
-"1269","SC340","SSCS Sutton","London Tribunals","7 NEWGATE STREET",,"London",,"EC1A 7AZ",,,"https://www.google.com/maps/place/7+Newgate+St,+London+EC1A+7AE/@51.5157644,-0.1010494,670m","Yes","London Tribunals Centre","Fox Court (S)",,"369230"
+"1269","SC340","SSCS Sutton","London Tribunals","7 NEWGATE STREET",,"London",,"EC1A 7AZ",,,"https://www.google.com/maps/place/7+Newgate+St,+London+EC1A+7AE/@51.5157644,-0.1010494,670m","Yes","London Tribunals Centre","",,"369230"


### PR DESCRIPTION
### Jira link


### Change description
Remove Fox Court (S) as a legacy venue for London Tribunals in sscs-venues.csv

### Testing done

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
