### PR TITLE
SSCSCI-2547 - add formatted confidentiality date label to Party

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/ConfidentialityTabBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/ConfidentialityTabBuilder.java
@@ -15,7 +15,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public final class ConfidentialityTabBuilder {
 
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("d MMM yyyy, h:mm:ss a", Locale.UK);
+    static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("d MMM yyyy, h:mm:ss a", Locale.UK);
 
     public static String buildConfidentialityTab(Benefit benefit, final Appeal appeal,
         final List<CcdValue<OtherParty>> otherParties) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Party.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/Party.java
@@ -1,7 +1,10 @@
 package uk.gov.hmcts.reform.sscs.ccd.domain;
 
+import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -29,5 +32,13 @@ public abstract class Party extends Entity {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private LocalDateTime confidentialityRequiredChangedDate;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(value = "confidentialityRequiredChangedDateLabel", access = READ_ONLY)
+    public String getConfidentialityRequiredChangedDateLabel() {
+        return confidentialityRequiredChangedDate != null
+            ? confidentialityRequiredChangedDate.format(ConfidentialityTabBuilder.FORMATTER)
+            : "";
+    }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/PartyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/domain/PartyTest.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.sscs.ccd.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class PartyTest {
+
+    private static final LocalDateTime DATE = LocalDateTime.of(2024, 1, 20, 9, 5, 3);
+
+    @Test
+    void shouldReturnEmptyLabelWhenDateIsNull() {
+        final Appellant appellant = Appellant.builder().build();
+
+        assertThat(appellant.getConfidentialityRequiredChangedDateLabel()).isEmpty();
+    }
+
+    @Test
+    void shouldReturnFormattedLabelWhenDateIsSet() {
+        final Appellant appellant = Appellant.builder().confidentialityRequiredChangedDate(DATE).build();
+
+        assertThat(appellant.getConfidentialityRequiredChangedDateLabel()).isEqualTo("20 Jan 2024, 9:05:03 am");
+    }
+}


### PR DESCRIPTION
### Jira link

See [SSCSCI-2547](https://tools.hmcts.net/jira/browse/SSCSCI-2547)

### Change description

Adds a computed READ_ONLY `confidentialityRequiredChangedDateLabel` getter on `Party`, returning the existing `confidentialityRequiredChangedDate` formatted as `d MMM yyyy, h:mm:ss a` (Locale.UK) to match the Confidentiality tab. Underlying `LocalDateTime` field is untouched. Made `ConfidentialityTabBuilder.FORMATTER` package-private to share.

### Testing done

Added `PartyTest` covering null and non-null cases. Verified end-to-end locally in sscs-tribunals-case-api (CCD ComplexTypes points at the new label field, Appeal Details / Other Party Details / Confidentiality tabs all render the same formatted timestamp).

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change