### PR TITLE
SSCSCI-2659 Add sendDirectionNoticeToOtherPartyAllowed to ExtendedSscsCaseData

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/ExtendedSscsCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/domain/ExtendedSscsCaseData.java
@@ -27,6 +27,9 @@ public class ExtendedSscsCaseData {
     private YesNo showConfidentialityTab;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    private YesNo sendDirectionNoticeToOtherPartyAllowed;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private YesNo writeFinalDecisionSevereYesNo;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)


### PR DESCRIPTION
Adds a `sendDirectionNoticeToOtherPartyAllowed` YesNo field to `ExtendedSscsCaseData`.

Needed by sscs-tribunals-case-api SSCSCI-2659: the Issue Direction Notice "send to other party" picker should only show for child support / UC cases with other parties. A show condition can't reference `appeal.benefitType.code` on the directionIssued event, so the handler sets this flag (JsonUnwrapped → top-level field) and the show condition points at it - same pattern as `showConfidentialityTab`.

No behaviour change in sscs-common; additive field only.